### PR TITLE
rpm: siegfried v1.6.7

### DIFF
--- a/rpm/siegfried/Dockerfile
+++ b/rpm/siegfried/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:7
 
 # Environmnet variables needed during build
-ENV GOVERSION 1.6
+ENV GOVERSION 1.7.5
 ENV GOOS linux
 ENV GOARCH amd64
 

--- a/rpm/siegfried/Makefile
+++ b/rpm/siegfried/Makefile
@@ -1,5 +1,5 @@
 NAME          = siegfried
-VERSION       = 1.5.0
+VERSION       = 1.6.7
 RPM_TOPDIR    = "/rpmbuild"
 DOCKER_VOLUME = "/src"
 DOCKER_IMAGE  = "rpmbuild-$(NAME)-$(VERSION)"
@@ -27,7 +27,7 @@ rpm-build: rpm-clean
 	cd /go/src/github.com/richardlehane/siegfried && git checkout v$(VERSION)
 
 	@echo "==> Building sources."
-	go install -tags archivematica -v github.com/richardlehane/siegfried/...
+	go install -tags archivematica -v github.com/richardlehane/siegfried/cmd/...
 
 	@echo "==> Preparing environment for rpmbuild."
 	mkdir -p $(RPM_TOPDIR)/{BUILD,RPMS,SRPMS}

--- a/rpm/siegfried/package.spec
+++ b/rpm/siegfried/package.spec
@@ -27,8 +27,11 @@ rm -rf $RPM_BUILD_ROOT
 %files
 /usr/bin/roy
 /usr/bin/sf
+/usr/share/siegfried/
 
-# Needed so sf can update the signature file.
-# Ideally, should the signature be saved somewhere else?
-%defattr(0644, 1000, 1000, 0755)
-/usr/share/siegfried
+%post
+userID=`id -u archivematica 2>/dev/null`
+if [ "${userID}" != 333 ]; then
+  useradd --uid 333 --user-group --home /var/lib/archivematica archivematica
+fi
+chown -R archivematica:archivematica /usr/share/siegfried


### PR DESCRIPTION
`go get` is used to download the dependencies not vendored by upstream. A separate pull request attempts to install the missing packages into the `vendor/` folder - see https://github.com/richardlehane/siegfried/pull/98.