### PR TITLE
xenial mcp-server: add debian/config file

### DIFF
--- a/debs/xenial/archivematica/debian-MCPServer/config
+++ b/debs/xenial/archivematica/debian-MCPServer/config
@@ -1,0 +1,15 @@
+#!/bin/sh
+# config maintainer script for archivematica-mcp-server
+
+# source debconf stuff
+. /usr/share/debconf/confmodule
+
+dbc_dbname=MCP
+dbc_dbuser=archivematica
+dbc_dbpass=demo
+
+# source dbconfig-common shell library, and call the hook function
+if [ -f /usr/share/dbconfig-common/dpkg/config.mysql ]; then
+  . /usr/share/dbconfig-common/dpkg/config.mysql
+  dbc_go archivematica-mcp-server $@
+fi


### PR DESCRIPTION
It's needed by dbconfig-common