### PR TITLE
rpm: fix typo in Makefile

### DIFF
--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -4,7 +4,7 @@ all: build createrepo
 
 build:
 	make -C ./siegfried
-	make -C ./storage-service
+	make -C ./archivematica-storage-service
 	make -C ./archivematica
 	make -C ./nailgun
 	make -C ./fits


### PR DESCRIPTION
This closes #121.