### PR TITLE
ss xenial: add ubuntu-externals package

### DIFF
--- a/debs/xenial/archivematica-storage-service/Dockerfile
+++ b/debs/xenial/archivematica-storage-service/Dockerfile
@@ -2,9 +2,13 @@ FROM ubuntu:xenial
 
 RUN apt-get update && \
     apt-get install -y dpkg-dev git build-essential wget debhelper \
-    devscripts equivs quilt
+    devscripts equivs quilt apt-transport-https
 
 RUN wget -O /tmp/pip.py https://bootstrap.pypa.io/get-pip.py && python /tmp/pip.py
+
+RUN wget -O - https://packages.archivematica.org/1.7.x/key.asc |\
+    apt-key add - && \
+    echo "deb [arch=amd64] http://packages.archivematica.org/1.7.x/ubuntu-externals xenial main" >> /etc/apt/sources.list
 
 # Dependencies are also obtained in the debian build script, this speeds up the process of building packages
 RUN apt-get update &&  apt-get install -y libffi-dev libssl-dev libxslt-dev dh-virtualenv python-dev dh-systemd libmysqlclient-dev postgresql-server-dev-9.5


### PR DESCRIPTION
It includes dh-virtualenv 1.0-1, that fixed problems with the
dashboard bin/gunicorn file

Refs:
 artefactual/archivematica#1042
 artefactual-labs/am-packbuild#155
 artefactual-labs/am-packbuild#152