### PR TITLE
xenial/storage-service: preinstall pip 9.0.3

### DIFF
--- a/debs/xenial/archivematica-storage-service/debian-storage-service/rules
+++ b/debs/xenial/archivematica-storage-service/debian-storage-service/rules
@@ -6,4 +6,8 @@ export DH_VIRTUALENV_INSTALL_ROOT=/usr/share/archivematica/virtualenvs
 	dh $@ --with python-virtualenv --with systemd
 
 override_dh_virtualenv:
-	dh_virtualenv --extra-pip-arg --find-links=lib 
+	# Preinstalling pip 9.0.3 solves a problem with the shebangs inside the
+	# virtual environment. See:
+	# - https://github.com/artefactual/archivematica/issues/1042
+	# - https://github.com/artefactual-labs/am-packbuild/pull/159
+	dh_virtualenv --preinstall "pip==9.0.3" --extra-pip-arg --find-links=lib


### PR DESCRIPTION
This closes https://github.com/artefactual/archivematica/issues/1042.

We changed the location of the virtual environment in https://github.com/artefactual-labs/am-packbuild/pull/122. In https://github.com/artefactual-labs/am-packbuild/pull/152 and https://github.com/artefactual-labs/am-packbuild/pull/156 we made sure that xenial/storage-service uses the most recent version of dh-virtualenv because this was causing a problem with shebangs  as described in https://github.com/artefactual/archivematica/issues/1042. The archivematica packages started working again after the upgrade to dh-virtualenv 1.0 but the problem persisted in the archivematica-storage-service package for unknown reasons.

I've been trying a few things and I came up with a solution: this pull request makes an additional change to `debian/rules` so `pip==9.0.3` is preinstalled inside the virtual environment. This seems to solve the problem, unfortunately I can't explain why the older version of pip was causing the shebangs to break.