### PR TITLE
Add management wrappers

### DIFF
--- a/rpm/archivematica-storage-service/etc/archivematica-storage-service-manage
+++ b/rpm/archivematica-storage-service/etc/archivematica-storage-service-manage
@@ -1,0 +1,45 @@
+#!/usr/share/archivematica/virtualenvs/archivematica-storage-service/bin/python
+
+import os
+import re
+import shlex
+import sys
+
+
+ENV_FILE = '/etc/sysconfig/archivematica-storage-service'
+
+
+def read_envfile(path):
+    try:
+        with open(path, 'r') as f:
+            content = f.read()
+    except getattr(__builtins__, 'FileNotFoundError', IOError):
+        return
+    for line in content.splitlines():
+        tokens = list(shlex.shlex(line, posix=True))
+        if len(tokens) < 3:
+            continue
+        name, op = tokens[:2]
+        value = ''.join(tokens[2:])
+        if op != '=':
+            continue
+        if not re.match(r'[A-Za-z_][A-Za-z_0-9]*', name):
+            continue
+        value = value.replace(r'\n', '\n').replace(r'\t', '\t')
+        os.environ.setdefault(name, value)
+
+
+def update_sys_path():
+    try:
+        python_path = os.environ['PYTHONPATH']
+    except KeyError:
+        return
+    for path in python_path.split(':'):
+        sys.path.append(path)
+
+
+if __name__ == "__main__":
+    read_envfile(ENV_FILE)
+    update_sys_path()
+    from django.core.management import execute_from_command_line
+    execute_from_command_line(sys.argv)

--- a/rpm/archivematica-storage-service/package.spec
+++ b/rpm/archivematica-storage-service/package.spec
@@ -26,6 +26,7 @@ The Storage Service is the mechanism by which Archivematica is able to store pac
 %config /etc/nginx/conf.d/archivematica-storage-service.conf
 %config /etc/archivematica/storage-service.gunicorn-config.py
 %config /etc/archivematica/storageService.logging.json
+/usr/bin/archivematica-storage-service-manage
 
 %prep
 rm -rf /usr/share/python/archivematica-storage-service
@@ -53,7 +54,8 @@ mkdir -p \
   %{buildroot}/usr/lib/systemd/system \
   %{buildroot}/etc/archivematica/ \
   %{buildroot}/etc/sysconfig/ \
-  %{buildroot}/etc/nginx/conf.d
+  %{buildroot}/etc/nginx/conf.d \
+  %{buildroot}/usr/bin/
 
 virtualenv /usr/share/archivematica/virtualenvs/archivematica-storage-service
 /usr/share/archivematica/virtualenvs/archivematica-storage-service/bin/pip install --upgrade pip
@@ -68,7 +70,7 @@ cp %{_sourcedir}/%{name}/install/storageService.logging.json %{buildroot}/etc/ar
 cp %{_etcdir}/archivematica-storage-service.service %{buildroot}/usr/lib/systemd/system/archivematica-storage-service.service
 cp %{_etcdir}/archivematica-storage-service.env %{buildroot}/etc/sysconfig/archivematica-storage-service
 cp %{_etcdir}/archivematica-storage-service.nginx %{buildroot}/etc/nginx/conf.d/archivematica-storage-service.conf
-
+cp %{_etcdir}/archivematica-storage-service-manage %{buildroot}/usr/bin/
 
 %clean
 rm -rf %{buildroot}

--- a/rpm/archivematica/archivematica.spec
+++ b/rpm/archivematica/archivematica.spec
@@ -116,6 +116,7 @@ Archivematica dashboard with Nginx + gunicorn.
 /usr/share/archivematica/virtualenvs/archivematica-dashboard/
 /usr/share/archivematica/dashboard/
 /usr/lib/systemd/system/archivematica-dashboard.service
+/usr/bin/archivematica-dashboard-manage
 %config /etc/sysconfig/archivematica-dashboard
 %config /etc/nginx/conf.d/archivematica-dashboard.conf
 %config /etc/archivematica/dashboard.gunicorn-config.py
@@ -159,7 +160,8 @@ mkdir -p \
   %{buildroot}/var/archivematica/sharedDirectory \
   %{buildroot}/etc/sysconfig \
   %{buildroot}/usr/lib/systemd/system \
-  %{buildroot}/etc/nginx/conf.d
+  %{buildroot}/etc/nginx/conf.d \
+  %{buildroot}/usr/bin/
 
 # Common
 cp -rf %{_sourcedir}/%{name}/src/archivematicaCommon/lib/* %{buildroot}/usr/lib/archivematica/archivematicaCommon/
@@ -213,6 +215,7 @@ cp %{_sourcedir}/%{name}/src/dashboard/install/dashboard.logging.json %{buildroo
 cp %{_etcdir}/archivematica-dashboard.service %{buildroot}/usr/lib/systemd/system/archivematica-dashboard.service
 cp %{_etcdir}/archivematica-dashboard.env %{buildroot}/etc/sysconfig/archivematica-dashboard
 cp %{_etcdir}/dashboard.nginx %{buildroot}/etc/nginx/conf.d/archivematica-dashboard.conf
+cp %{_etcdir}/archivematica-dashboard-manage %{buildroot}/usr/bin/
 
 
 #

--- a/rpm/archivematica/etc/archivematica-dashboard-manage
+++ b/rpm/archivematica/etc/archivematica-dashboard-manage
@@ -1,0 +1,45 @@
+#!/usr/share/archivematica/virtualenvs/archivematica-dashboard/bin/python
+
+import os
+import re
+import shlex
+import sys
+
+
+ENV_FILE = '/etc/sysconfig/archivematica-dashboard'
+
+
+def read_envfile(path):
+    try:
+        with open(path, 'r') as f:
+            content = f.read()
+    except getattr(__builtins__, 'FileNotFoundError', IOError):
+        return
+    for line in content.splitlines():
+        tokens = list(shlex.shlex(line, posix=True))
+        if len(tokens) < 3:
+            continue
+        name, op = tokens[:2]
+        value = ''.join(tokens[2:])
+        if op != '=':
+            continue
+        if not re.match(r'[A-Za-z_][A-Za-z_0-9]*', name):
+            continue
+        value = value.replace(r'\n', '\n').replace(r'\t', '\t')
+        os.environ.setdefault(name, value)
+
+
+def update_sys_path():
+    try:
+        python_path = os.environ['PYTHONPATH']
+    except KeyError:
+        return
+    for path in python_path.split(':'):
+        sys.path.append(path)
+
+
+if __name__ == "__main__":
+    read_envfile(ENV_FILE)
+    update_sys_path()
+    from django.core.management import execute_from_command_line
+    execute_from_command_line(sys.argv)


### PR DESCRIPTION
This pull request aims to add two management commands globally available when packages are installed.

- `archivematica-dashboard-manage`
- `archivematica-storage-service-manage`

Changes:
- [X] Update **rpm/centos7** (see b63ca60a02fdc2366b775b9ea2b10ccd4ea2580e)
- [ ] Update **deb/trusty**
- [ ] Update **deb/xenial**
- [ ] Update **ansible**
- [ ] Update **docs**

This closes #157. The idea is to provide a shortcut to the user so instead of running snippets like the following:

```
sudo -u archivematica bash -c " \
    set -a -e -x
    source /etc/sysconfig/archivematica-storage-service
    cd /usr/lib/archivematica/storage-service
    /usr/share/archivematica/virtualenvs/archivematica-storage-service/bin/python manage.py migrate
";
```

The user would only need to run:

    sudo -u archivematica archivematica-storage-service-manage migrate