### PR TITLE
xenial: preinstall pip 9.0.3

### DIFF
--- a/debs/xenial/archivematica/debian-MCPClient/rules
+++ b/debs/xenial/archivematica/debian-MCPClient/rules
@@ -8,4 +8,4 @@ export DH_VIRTUALENV_INSTALL_ROOT=/usr/share/archivematica/virtualenvs
 override_dh_virtualenv:
 	dh_virtualenv --requirements ../archivematicaCommon/requirements/production.txt --skip-install
 	dh_virtualenv --requirements ../dashboard/src/requirements/production.txt --skip-install
-	dh_virtualenv --skip-install 
+	dh_virtualenv --preinstall "pip==9.0.3" --skip-install

--- a/debs/xenial/archivematica/debian-MCPServer/rules
+++ b/debs/xenial/archivematica/debian-MCPServer/rules
@@ -8,4 +8,4 @@ export DH_VIRTUALENV_INSTALL_ROOT=/usr/share/archivematica/virtualenvs
 override_dh_virtualenv:
 	dh_virtualenv --requirements ../archivematicaCommon/requirements/production.txt --skip-install
 	dh_virtualenv --requirements ../dashboard/src/requirements/production.txt --skip-install
-	dh_virtualenv --skip-install
+	dh_virtualenv --preinstall "pip==9.0.3" --skip-install

--- a/debs/xenial/archivematica/debian-dashboard/rules
+++ b/debs/xenial/archivematica/debian-dashboard/rules
@@ -7,5 +7,4 @@ export DH_VIRTUALENV_INSTALL_ROOT=/usr/share/archivematica/virtualenvs
 
 override_dh_virtualenv:
 	dh_virtualenv --requirements ../archivematicaCommon/requirements/production.txt --skip-install
-	dh_virtualenv -v --skip-install -D src/ 
-
+	dh_virtualenv -v --preinstall "pip==9.0.3" --skip-install -D src/


### PR DESCRIPTION
With https://github.com/artefactual-labs/am-packbuild/pull/159 merged I can confirm that the shebang issue disappeared from the packages being built by Jenkins:

```
$ wget http://jenkins-ci.archivematica.org/repos/apt/release-0.11-xenial/archivematica-storage-service_0.11.0~rc.7_amd64.deb
$ md5 archivematica-storage-service_0.11.0~rc.7_amd64.deb
MD5 (archivematica-storage-service_0.11.0~rc.7_amd64.deb) = 41e54b6f7101d4f45f0c8b9716e1cf97
$ unar archivematica-storage-service_0.11.0~rc.7_amd64.deb
$ cd archivematica-storage-service_0.11.0~rc.7_amd64
$ tar xf data.tar.xz
$ head -n1 ./usr/share/archivematica/virtualenvs/archivematica-storage-service/bin/gunicorn
#!/usr/share/archivematica/virtualenvs/archivematica-storage-service/bin/python
```

This pull requests extends #159 to the other Archivematica packages using dh-virtualenv. We didn't see this issue happening the other day when we upgraded dh-virtualenv to v1.0 but it's happening now for unknown reasons. Too many unknowns for my taste but I'm glad at least we have a fix.

Yet another fix in regards to https://github.com/artefactual/archivematica/issues/1042.