### PR TITLE
Ubuntu: Configure ucf for files in /etc/default/

### DIFF
--- a/debs/trusty/archivematica-storage-service/debian-storage-service/postinst
+++ b/debs/trusty/archivematica-storage-service/debian-storage-service/postinst
@@ -19,6 +19,10 @@ echo $KEYCMD
 sed -i "s/<replace-with-key>/\"$KEYCMD\"/g" /var/archivematica/.storage-service
 sed -i "s/<replace-with-key>/$KEYCMD/g" /etc/archivematica/storage-service.gunicorn-config.py
 
+# Use ucf to preserve user changes in the default file
+ucfr archivematica-storage-service /etc/default/archivematica-storage-service
+ucf --debconf-ok /etc/default/archivematica-storage-service /etc/default/archivematica-storage-service
+
 . /var/archivematica/.storage-service
 export $(cat /etc/default/archivematica-storage-service)
 echo "creating symlink in /usr/lib/archivematica"

--- a/debs/trusty/archivematica-storage-service/debian-storage-service/postrm
+++ b/debs/trusty/archivematica-storage-service/debian-storage-service/postrm
@@ -16,7 +16,14 @@ if [ $1 = "remove" ]; then
     rm -f /etc/uwsgi/apps-enabled/storage.ini
     rm -f /etc/uwsgi/apps-available/storage.ini
     rm -rf /usr/lib/archivematica/storage*
+fi
 
+if [ "$1" = "purge" ]; then
+    rm -f /etc/default/archivematica-storage-service
+    if which ucf >/dev/null 2>&1; then
+        ucf --purge /etc/default/archivematica-storage-service
+        ucfr --purge archivematica-storage-service /etc/default/archivematica-storage-service
+    fi
 fi
 
 exit 0

--- a/debs/trusty/archivematica/debian-MCPClient/postinst
+++ b/debs/trusty/archivematica/debian-MCPClient/postinst
@@ -18,6 +18,10 @@ sed -i "s/^\(ARCHIVEMATICA_MCPCLIENT_CLIENT_USER=\).*/\1$DBUSER/g" /etc/default/
 DBNAME=$(grep "dbc_dbname=" /etc/dbconfig-common/archivematica-mcp-server.conf| cut -d\= -f2- | tr -d \')
 sed -i "s/^\(ARCHIVEMATICA_MCPCLIENT_CLIENT_DATABASE=\).*/\1$DBNAME/g" /etc/default/archivematica-mcp-client
 
+# Use ucf to preserve user changes in the default file
+ucfr archivematica-mcp-client /etc/default/archivematica-mcp-client
+ucf --debconf-ok /etc/default/archivematica-mcp-client /etc/default/archivematica-mcp-client
+
 logdir=/var/log/archivematica/MCPClient
 mkdir -p $logdir
 chown -R archivematica:archivematica $logdir

--- a/debs/trusty/archivematica/debian-MCPClient/postrm
+++ b/debs/trusty/archivematica/debian-MCPClient/postrm
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ "$1" = "purge" ]; then
+    rm -f /etc/default/archivematica-mcp-client
+    if which ucf >/dev/null 2>&1; then
+        ucf --purge /etc/default/archivematica-mcp-client
+        ucfr --purge archivematica-mcp-client /etc/default/archivematica-mcp-client
+    fi
+fi

--- a/debs/trusty/archivematica/debian-MCPServer/postinst
+++ b/debs/trusty/archivematica/debian-MCPServer/postinst
@@ -26,6 +26,9 @@ sed -i "s/^\(ARCHIVEMATICA_MCPSERVER_CLIENT_USER=\).*/\1$DBUSER/g" /etc/default/
 DBNAME=$(grep "dbc_dbname=" /etc/dbconfig-common/archivematica-mcp-server.conf| cut -d\= -f2- | tr -d \')
 sed -i "s/^\(ARCHIVEMATICA_MCPSERVER_CLIENT_DATABASE=\).*/\1$DBNAME/g" /etc/default/archivematica-mcp-server
 
+# Use ucf to preserve user changes in the default file
+ucfr archivematica-mcp-server /etc/default/archivematica-mcp-server
+ucf --debconf-ok /etc/default/archivematica-mcp-server /etc/default/archivematica-mcp-server
 
 #DEBHELPER#
 

--- a/debs/trusty/archivematica/debian-MCPServer/postrm
+++ b/debs/trusty/archivematica/debian-MCPServer/postrm
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ "$1" = "purge" ]; then
+    rm -f /etc/default/archivematica-mcp-server
+    if which ucf >/dev/null 2>&1; then
+        ucf --purge /etc/default/archivematica-mcp-server
+        ucfr --purge archivematica-mcp-server /etc/default/archivematica-mcp-server
+    fi
+fi

--- a/debs/trusty/archivematica/debian-dashboard/postinst
+++ b/debs/trusty/archivematica/debian-dashboard/postinst
@@ -28,7 +28,9 @@ sed -i "s/^\(ARCHIVEMATICA_DASHBOARD_CLIENT_USER=\).*/\1$DBUSER/g" /etc/default/
 DBNAME=$(grep "dbc_dbname=" /etc/dbconfig-common/archivematica-mcp-server.conf| cut -d\= -f2- | tr -d \')
 sed -i "s/^\(ARCHIVEMATICA_DASHBOARD_CLIENT_DATABASE=\).*/\1$DBNAME/g" /etc/default/archivematica-dashboard
 
-
+# Use ucf to preserve user changes in the default file
+ucfr archivematica-dashboard /etc/default/archivematica-dashboard
+ucf --debconf-ok /etc/default/archivematica-dashboard /etc/default/archivematica-dashboard
 
 #this is required to allow syncdb to work properly
 export $(cat /etc/default/archivematica-dashboard)
@@ -44,7 +46,9 @@ fi
 
 # Run migrations
 /usr/share/archivematica/dashboard/manage.py migrate --settings='settings.production'
+
 # Collect static content
 /usr/share/archivematica/dashboard/manage.py collectstatic --noinput
+
 
 #DEBHELPER#

--- a/debs/trusty/archivematica/debian-dashboard/postrm
+++ b/debs/trusty/archivematica/debian-dashboard/postrm
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ "$1" = "purge" ]; then
+    rm -f /etc/default/archivematica-dashboard
+    if which ucf >/dev/null 2>&1; then
+        ucf --purge /etc/default/archivematica-dashboard
+        ucfr --purge archivematica-dashboard /etc/default/archivematica-dashboard
+    fi
+fi

--- a/debs/xenial/archivematica-storage-service/debian-storage-service/postinst
+++ b/debs/xenial/archivematica-storage-service/debian-storage-service/postinst
@@ -21,6 +21,10 @@ echo $KEYCMD
 sed -i "s/CHANGE_ME_WITH_A_SECRET_KEY/\"$KEYCMD\"/g" /etc/default/archivematica-storage-service
 sed -i "s/<replace-with-key>/$KEYCMD/g" /etc/archivematica/storage-service.gunicorn-config.py
 
+# Use ucf to preserve user changes in the default file
+ucfr archivematica-storage-service /etc/default/archivematica-storage-service
+ucf --debconf-ok /etc/default/archivematica-storage-service /etc/default/archivematica-storage-service
+
 export $(cat /etc/default/archivematica-storage-service)
 echo "creating symlink in /usr/lib/archivematica"
 rm -f /usr/lib/archivematica/storage-service

--- a/debs/xenial/archivematica-storage-service/debian-storage-service/postrm
+++ b/debs/xenial/archivematica-storage-service/debian-storage-service/postrm
@@ -18,6 +18,14 @@ if [ $1 = "remove" ]; then
     rm -rf /usr/lib/archivematica/storage*
 fi
 
+if [ "$1" = "purge" ]; then
+    rm -f /etc/default/archivematica-storage-service
+    if which ucf >/dev/null 2>&1; then
+        ucf --purge /etc/default/archivematica-storage-service
+        ucfr --purge archivematica-storage-service /etc/default/archivematica-storage-service
+    fi
+fi
+
 exit 0
 
 #DEBHELPER#

--- a/debs/xenial/archivematica/debian-MCPClient/postinst
+++ b/debs/xenial/archivematica/debian-MCPClient/postinst
@@ -15,6 +15,9 @@ sed -i "s/^\(ARCHIVEMATICA_MCPCLIENT_CLIENT_USER=\).*/\1$DBUSER/g" /etc/default/
 DBNAME=$(grep "dbc_dbname=" /etc/dbconfig-common/archivematica-mcp-server.conf| cut -d\= -f2- | tr -d \')
 sed -i "s/^\(ARCHIVEMATICA_MCPCLIENT_CLIENT_DATABASE=\).*/\1$DBNAME/g" /etc/default/archivematica-mcp-client
 
+# Use ucf to preserve user changes in the default file
+ucfr archivematica-mcp-client /etc/default/archivematica-mcp-client
+ucf --debconf-ok /etc/default/archivematica-mcp-client /etc/default/archivematica-mcp-client
 
 #DEBHELPER#
 

--- a/debs/xenial/archivematica/debian-MCPClient/postrm
+++ b/debs/xenial/archivematica/debian-MCPClient/postrm
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ "$1" = "purge" ]; then
+    rm -f /etc/default/archivematica-mcp-client
+    if which ucf >/dev/null 2>&1; then
+        ucf --purge /etc/default/archivematica-mcp-client
+        ucfr --purge archivematica-mcp-client /etc/default/archivematica-mcp-client
+    fi
+fi

--- a/debs/xenial/archivematica/debian-MCPServer/postinst
+++ b/debs/xenial/archivematica/debian-MCPServer/postinst
@@ -25,6 +25,9 @@ sed -i "s/^\(ARCHIVEMATICA_MCPSERVER_CLIENT_USER=\).*/\1$DBUSER/g" /etc/default/
 DBNAME=$(grep "dbc_dbname=" /etc/dbconfig-common/archivematica-mcp-server.conf| cut -d\= -f2- | tr -d \')
 sed -i "s/^\(ARCHIVEMATICA_MCPSERVER_CLIENT_DATABASE=\).*/\1$DBNAME/g" /etc/default/archivematica-mcp-server
 
+# Use ucf to preserve user changes in the default file
+ucfr archivematica-mcp-server /etc/default/archivematica-mcp-server
+ucf --debconf-ok /etc/default/archivematica-mcp-server /etc/default/archivematica-mcp-server
 
 #DEBHELPER#
 

--- a/debs/xenial/archivematica/debian-MCPServer/postrm
+++ b/debs/xenial/archivematica/debian-MCPServer/postrm
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ "$1" = "purge" ]; then
+    rm -f /etc/default/archivematica-mcp-server
+    if which ucf >/dev/null 2>&1; then
+        ucf --purge /etc/default/archivematica-mcp-server
+        ucfr --purge archivematica-mcp-server /etc/default/archivematica-mcp-server
+    fi
+fi

--- a/debs/xenial/archivematica/debian-dashboard/postinst
+++ b/debs/xenial/archivematica/debian-dashboard/postinst
@@ -28,7 +28,9 @@ sed -i "s/^\(ARCHIVEMATICA_DASHBOARD_CLIENT_USER=\).*/\1$DBUSER/g" /etc/default/
 DBNAME=$(grep "dbc_dbname=" /etc/dbconfig-common/archivematica-mcp-server.conf| cut -d\= -f2- | tr -d \')
 sed -i "s/^\(ARCHIVEMATICA_DASHBOARD_CLIENT_DATABASE=\).*/\1$DBNAME/g" /etc/default/archivematica-dashboard
 
-
+# Use ucf to preserve user changes in the default file
+ucfr archivematica-dashboard /etc/default/archivematica-dashboard
+ucf --debconf-ok /etc/default/archivematica-dashboard /etc/default/archivematica-dashboard
 
 #this is required to allow syncdb to work properly
 export $(cat /etc/default/archivematica-dashboard)

--- a/debs/xenial/archivematica/debian-dashboard/postrm
+++ b/debs/xenial/archivematica/debian-dashboard/postrm
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ "$1" = "purge" ]; then
+    rm -f /etc/default/archivematica-dashboard
+    if which ucf >/dev/null 2>&1; then
+        ucf --purge /etc/default/archivematica-dashboard
+        ucfr --purge archivematica-dashboard /etc/default/archivematica-dashboard
+    fi
+fi


### PR DESCRIPTION
The apt tool sometimes asks whether to keep the current version of the
/etc/default conf files when upgrading archivematica packages, even
without having modified these files.

In this PR these files are added to ucf (Update Configuration File) so
on an upgrade or a reconfiguration the system will only ask for the
action to be taken when those files have actually been changed.

Fixes #96