### PR TITLE
Fix trusty/ss patch

### DIFF
--- a/debs/trusty/archivematica-storage-service/debian-storage-service/patches/storage-service-init.diff
+++ b/debs/trusty/archivematica-storage-service/debian-storage-service/patches/storage-service-init.diff
@@ -6,7 +6,7 @@ Index: archivematica-storage-service/install/archivematica-storage-service.conf
  env LC_ALL="en_US.UTF-8"
  env LC_LANG="en_US.UTF-8"
  
--exec /usr/share/archivematica/virtualenvs/archivematica-storage-service/bin/gunicorn --config /etc/archivematica/storage-service.gunicorn-config.py storage_service.wsgi:application
+-exec /usr/share/python/archivematica-storage-service/bin/gunicorn --config /etc/archivematica/storage-service.gunicorn-config.py storage_service.wsgi:application
 +script
 +  export $(cat /etc/default/archivematica-storage-service)
 +  exec /usr/share/archivematica/virtualenvs/archivematica-storage-service/bin/gunicorn --config /etc/archivematica/storage-service.gunicorn-config.py storage_service.wsgi:application


### PR DESCRIPTION
This reverts a change I made in d7c4834a4d8d5e63233bcf6219baa3ded24bb203 that
broke the patch that updates the service definition causing the build to break.

This closes https://github.com/artefactual-labs/am-packbuild/issues/166.