### PR TITLE
rpm/siegfried: stop using %defattr directive

### DIFF
--- a/rpm/siegfried/package.spec
+++ b/rpm/siegfried/package.spec
@@ -27,8 +27,4 @@ rm -rf $RPM_BUILD_ROOT
 %files
 /usr/bin/roy
 /usr/bin/sf
-
-# Needed so sf can update the signature file.
-# Ideally, should the signature be saved somewhere else?
-%defattr(0644, 1000, 1000, 0755)
 /usr/share/siegfried


### PR DESCRIPTION
This fixes #151 - we were not using the `%defattr` directive properly. This
commits removes it. It seams reasonable to expect that the user wanting to
update the signature file needs root privileges.