### PR TITLE
Update changelogs after 1.7 release

### DIFF
--- a/debs/trusty/archivematica-storage-service/debian-storage-service/changelog
+++ b/debs/trusty/archivematica-storage-service/debian-storage-service/changelog
@@ -1,3 +1,10 @@
+archivematica-storage-service (1:0.11.0-1~14.04) trusty; urgency=high
+
+  * commit: 5a6ce126fec6afea9947714da30ad8533bfc5620
+  * checkout: v0.11.0
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Tue, 01 May 2018 20:27:41 +0000
+
 archivematica-storage-service (1:0.10.1-1~14.04) trusty; urgency=high
 
   * commit: 1afb22aa7c05d1ba43dc531536b8e49dfe4c2da8

--- a/debs/trusty/archivematica/debian-MCPClient/changelog
+++ b/debs/trusty/archivematica/debian-MCPClient/changelog
@@ -1,3 +1,10 @@
+archivematica-mcp-client (1:1.7.0-1~14.04) trusty; urgency=high
+
+  * commit: 353fb054bfed3cce09cc10e08068712aba2219fb
+  * checkout: v1.7.0
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Tue, 01 May 2018 20:20:56 +0000
+
 archivematica-mcp-client (1:1.6.1-2~16.04) trusty; urgency=high
 
   * commit: 11e89646f2708d525ba5f19ccce9b4879b02a619

--- a/debs/trusty/archivematica/debian-MCPServer/changelog
+++ b/debs/trusty/archivematica/debian-MCPServer/changelog
@@ -1,3 +1,10 @@
+archivematica-mcp-server (1:1.7.0-1~14.04) trusty; urgency=high
+
+  * commit: 353fb054bfed3cce09cc10e08068712aba2219fb
+  * checkout: v1.7.0
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Tue, 01 May 2018 20:23:17 +0000
+
 archivematica-mcp-server (1:1.6.1-2~16.04) trusty; urgency=high
 
   * commit: 11e89646f2708d525ba5f19ccce9b4879b02a619

--- a/debs/trusty/archivematica/debian-archivematicaCommon/changelog
+++ b/debs/trusty/archivematica/debian-archivematicaCommon/changelog
@@ -1,3 +1,10 @@
+archivematica-common (1:1.7.0-1~14.04) trusty; urgency=high
+
+  * commit: 353fb054bfed3cce09cc10e08068712aba2219fb
+  * checkout: v1.7.0
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Tue, 01 May 2018 20:25:25 +0000
+
 archivematica-common (1:1.6.1-2~16.04) trusty; urgency=high
 
   * commit: 11e89646f2708d525ba5f19ccce9b4879b02a619

--- a/debs/trusty/archivematica/debian-dashboard/changelog
+++ b/debs/trusty/archivematica/debian-dashboard/changelog
@@ -1,3 +1,10 @@
+rchivematica-dashboard (1:1.7.0-1~14.04) trusty; urgency=high
+
+  * commit: 353fb054bfed3cce09cc10e08068712aba2219fb
+  * checkout: v1.7.0
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Tue, 01 May 2018 20:14:51 +0000
+
 archivematica-dashboard (1:1.6.1-2~16.04) trusty; urgency=high
 
   * commit: 11e89646f2708d525ba5f19ccce9b4879b02a619

--- a/debs/xenial/archivematica-storage-service/debian-storage-service/changelog
+++ b/debs/xenial/archivematica-storage-service/debian-storage-service/changelog
@@ -1,3 +1,10 @@
+archivematica-storage-service (1:0.11.0-1~16.04) xenial; urgency=high
+
+  * commit: 5a6ce126fec6afea9947714da30ad8533bfc5620
+  * checkout: v0.11.0
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Tue, 01 May 2018 21:18:57 +0000
+
 archivematica-storage-service (1:0.10.1-2~16.04) trusty; urgency=high
 
   * commit: 1afb22aa7c05d1ba43dc531536b8e49dfe4c2da8

--- a/debs/xenial/archivematica/debian-MCPClient/changelog
+++ b/debs/xenial/archivematica/debian-MCPClient/changelog
@@ -1,3 +1,10 @@
+archivematica-mcp-client (1:1.7.0-1~16.04) xenial; urgency=high
+
+  * commit: 353fb054bfed3cce09cc10e08068712aba2219fb
+  * checkout: v1.7.0
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Tue, 01 May 2018 21:11:34 +0000
+
 archivematica-mcp-client (1:1.6.1-2~16.04) xenial; urgency=high
 
   * commit: 11e89646f2708d525ba5f19ccce9b4879b02a619

--- a/debs/xenial/archivematica/debian-MCPServer/changelog
+++ b/debs/xenial/archivematica/debian-MCPServer/changelog
@@ -1,3 +1,10 @@
+archivematica-mcp-server (1:1.7.0-1~16.04) xenial; urgency=high
+
+  * commit: 353fb054bfed3cce09cc10e08068712aba2219fb
+  * checkout: v1.7.0
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Tue, 01 May 2018 21:14:13 +0000
+
 archivematica-mcp-server (1:1.6.1-2~16.04) xenial; urgency=high
 
   * commit: 11e89646f2708d525ba5f19ccce9b4879b02a619

--- a/debs/xenial/archivematica/debian-archivematicaCommon/changelog
+++ b/debs/xenial/archivematica/debian-archivematicaCommon/changelog
@@ -1,3 +1,10 @@
+archivematica-common (1:1.7.0-1~16.04) xenial; urgency=high
+
+  * commit: 353fb054bfed3cce09cc10e08068712aba2219fb
+  * checkout: v1.7.0
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Tue, 01 May 2018 21:16:33 +0000
+
 archivematica-common (1:1.6.1-2~16.04) xenial; urgency=high
 
   * commit: 11e89646f2708d525ba5f19ccce9b4879b02a619

--- a/debs/xenial/archivematica/debian-dashboard/changelog
+++ b/debs/xenial/archivematica/debian-dashboard/changelog
@@ -1,3 +1,10 @@
+archivematica-dashboard (1:1.7.0-1~16.04) xenial; urgency=high
+
+  * commit: 353fb054bfed3cce09cc10e08068712aba2219fb
+  * checkout: v1.7.0
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Tue, 01 May 2018 21:03:54 +0000
+
 archivematica-dashboard (1:1.6.1-2~16.04) xenial; urgency=high
 
   * commit: 11e89646f2708d525ba5f19ccce9b4879b02a619


### PR DESCRIPTION
As changelogs are created in the build process, is a good practice updating them after the release is done.

Due to #169, I tweaked the changelogs from the official packages available at https://packages.archivematica.org/1.7.x/ubuntu, to show the tag used in the build.