### PR TITLE
rpm fits: Disable mediainfo on fits for CentOS/RH

### DIFF
--- a/rpm/fits/files/fits-disable-mediainfo.patch
+++ b/rpm/fits/files/fits-disable-mediainfo.patch
@@ -1,0 +1,11 @@
+--- xml/fits.xml.orig	2018-05-08 17:12:07.000000000 +0200
++++ xml/fits.xml	2018-05-08 17:12:26.000000000 +0200
+@@ -3,7 +3,7 @@
+ 	<!-- Order of the tools determines preference -->
+ 	<tools>
+ 		<!-- exclude-exts attribute is a comma delimited list of file extensions that the tool should not try to process -->
+-        <tool class="edu.harvard.hul.ois.fits.tools.mediainfo.MediaInfo" include-exts="avi,mov,mpg,mpeg,mkv,mp4,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv,m2ts,mpeg4" classpath-dirs="lib/mediainfo" />
++	<!-- <tool class="edu.harvard.hul.ois.fits.tools.mediainfo.MediaInfo" include-exts="avi,mov,mpg,mpeg,mkv,mp4,mxf,ogv,mj2,divx,dv,m4v,m2v,ismv,m2ts,mpeg4" classpath-dirs="lib/mediainfo" /> -->
+         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.AudioInfo" include-exts="wav" classpath-dirs="lib/audioinfo" />
+         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.ADLTool" include-exts="adl" classpath-dirs="lib/adltool" />
+         <tool class="edu.harvard.hul.ois.fits.tools.oisfileinfo.VTTTool" include-exts="vtt" />    

--- a/rpm/fits/package.spec
+++ b/rpm/fits/package.spec
@@ -8,6 +8,7 @@ Patch: fits-home.patch
 Patch1: fits-log4j.patch
 Patch2: fits-enable-toolOutput.patch
 Patch3: fits-use-system-exitftool.patch
+Patch4: fits-disable-mediainfo.patch
 Requires: mediainfo, libzen, perl-Image-ExifTool, nailgun
 License: GPLv3
 
@@ -31,6 +32,7 @@ rm -rf %{buildroot}/*
 %patch1
 %patch2
 %patch3
+%patch4
 
 %install
 ANT_OPTS=-Dfile.encoding=UTF8 ant clean-compile-jar


### PR DESCRIPTION
Fixes #172