### PR TITLE
fits: update release

### DIFF
--- a/rpm/fits/package.spec
+++ b/rpm/fits/package.spec
@@ -1,6 +1,6 @@
 Name: %{name}
 Version: %{version}
-Release: 3%{?dist}
+Release: 4%{?dist}
 Summary: File Information Tool Set (FITS)
 Buildrequires: ant, gcc
 Source: https://github.com/harvard-lts/fits/archive/v%{version}.zip


### PR DESCRIPTION
After #172, we need to build and up a new package with an updated release number, and add it to the repo

Fixes #174