### PR TITLE
rpm: create archivematica homedir

### DIFF
--- a/rpm/archivematica-storage-service/package.spec
+++ b/rpm/archivematica-storage-service/package.spec
@@ -80,9 +80,9 @@ rm -rf %{buildroot}
 getent group archivematica >/dev/null || groupadd -f -g 333 -r archivematica
 if ! getent passwd archivematica >/dev/null ; then
   if ! getent passwd 333 >/dev/null ; then
-    useradd -r -u 333 -g archivematica -d /var/lib/archivematica/ -s /sbin/nologin -c "Archivematica system account" archivematica
+    useradd -r -u 333 -g archivematica -d /var/lib/archivematica/ -s /sbin/nologin -c "Archivematica system account" -m archivematica
     else
-    useradd -r -g archivematica -d /var/lib/archivematica/ -s /sbin/nologin -c "Archivematica system account" archivematica
+    useradd -r -g archivematica -d /var/lib/archivematica/ -s /sbin/nologin -c "Archivematica system account" -m archivematica
     fi
 fi
 

--- a/rpm/archivematica/archivematica.spec
+++ b/rpm/archivematica/archivematica.spec
@@ -235,9 +235,9 @@ rm -rf %{buildroot}
 getent group archivematica >/dev/null || groupadd -f -g 333 -r archivematica
 if ! getent passwd archivematica >/dev/null ; then
   if ! getent passwd 333 >/dev/null ; then
-    useradd -r -u 333 -g archivematica -d /var/lib/archivematica/ -s /sbin/nologin -c "Archivematica system account" archivematica
+    useradd -r -u 333 -g archivematica -d /var/lib/archivematica/ -s /sbin/nologin -c "Archivematica system account" -m archivematica
     else
-    useradd -r -g archivematica -d /var/lib/archivematica/ -s /sbin/nologin -c "Archivematica system account" archivematica
+    useradd -r -g archivematica -d /var/lib/archivematica/ -s /sbin/nologin -c "Archivematica system account" -m archivematica
   fi
 fi
 


### PR DESCRIPTION
This commit will create the /var/lib/archivematica directory when adding the archivematica user. The "-m" option was missing in the `useradd` command.

Fixes #185 