### PR TITLE
fits centos: fix relative paths issue

### DIFF
--- a/rpm/fits/files/fits-home.patch
+++ b/rpm/fits/files/fits-home.patch
@@ -1,6 +1,6 @@
---- fits-env.sh.orig    2018-10-15 12:56:32.314319133 +0200
-+++ fits-env.sh 2018-10-15 12:56:52.626363167 +0200
-@@ -17,9 +17,10 @@
+--- fits-env.sh-orig	2018-10-23 20:02:04.517332753 +0200
++++ fits-env.sh	2018-10-23 20:02:51.050251154 +0200
+@@ -17,7 +17,7 @@
    fi
  done
  
@@ -8,8 +8,4 @@
 +FITS_HOME="/usr/share/fits"
  
  export FITS_HOME
-+cd $FITS_HOME
- 
- # Uncomment the following line if you want "file utility" to dereference and follow symlinks.
- # export POSIXLY_CORRECT=1
 

--- a/rpm/fits/files/fits-logging.patch
+++ b/rpm/fits/files/fits-logging.patch
@@ -1,0 +1,10 @@
+--- fits.sh-orig	2018-10-23 20:12:30.142012129 +0200
++++ fits.sh	2018-10-23 20:16:50.971424713 +0200
+@@ -16,6 +16,6 @@
+ 
+ . "$(dirname $FITS_SCRIPT)/fits-env.sh"
+ 
+-cmd="java -classpath \"$APPCLASSPATH\" edu.harvard.hul.ois.fits.Fits $args"
++cmd="java -Dlog4j.configuration=file:\"$FITS_HOME\"/log4j.properties -classpath \"$APPCLASSPATH\" edu.harvard.hul.ois.fits.Fits $args"
+ 
+ eval "exec $cmd"

--- a/rpm/fits/files/fits-ngserver-logging.patch
+++ b/rpm/fits/files/fits-ngserver-logging.patch
@@ -1,0 +1,11 @@
+--- fits-ngserver.sh-orig	2018-10-23 20:18:27.621439745 +0200
++++ fits-ngserver.sh	2018-10-23 20:20:45.943777149 +0200
+@@ -17,7 +17,7 @@
+ 	NAILGUN_JAR=$1
+ fi
+ 
+-cmd="java -classpath \"$APPCLASSPATH:$NAILGUN_JAR\" com.martiansoftware.nailgun.NGServer"
++cmd="java -Dlog4j.configuration=file:\"$FITS_HOME\"/log4j.properties -classpath \"$APPCLASSPATH:$NAILGUN_JAR\" com.martiansoftware.nailgun.NGServer"
+ 
+ echo "You may now run FITS by typing: ng edu.harvard.hul.ois.fits.Fits [options]" >&2
+ 

--- a/rpm/fits/package.spec
+++ b/rpm/fits/package.spec
@@ -1,7 +1,7 @@
 %global _default_patch_fuzz 2
 Name: %{name}
 Version: %{version}
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: File Information Tool Set (FITS)
 Buildrequires: ant, gcc
 Source: https://github.com/harvard-lts/fits/archive/v%{version}.zip
@@ -10,6 +10,8 @@ Patch1: fits-log4j.patch
 Patch2: fits-enable-toolOutput.patch
 Patch3: fits-use-system-exitftool.patch
 Patch4: fits-disable-mediainfo.patch
+Patch5: fits-ngserver-logging.patch
+Patch6: fits-logging.patch
 Requires: mediainfo, libzen, perl-Image-ExifTool, nailgun
 License: GPLv3
 
@@ -34,6 +36,8 @@ rm -rf %{buildroot}/*
 %patch2
 %patch3
 %patch4
+%patch5
+%patch6
 
 %install
 ANT_OPTS=-Dfile.encoding=UTF8 ant clean-compile-jar


### PR DESCRIPTION
This PR fixes an issue when using relative paths and defines the
log4j.configuration file directly in the java command for fits.sh and
fits-ngserver.sh.

Connects to https://github.com/archivematica/Issues/issues/247