### PR TITLE
fits ubuntu: fix relative paths issue

### DIFF
--- a/debs/bionic/fits/Makefile
+++ b/debs/bionic/fits/Makefile
@@ -1,6 +1,6 @@
 NAME          = fits
 VERSION       ?= 1.1.0
-RELEASE	      ?= 3~18.04
+RELEASE	      ?= 4~18.04
 GIT_URL	      = https://github.com/harvard-lts/fits
 GPG_ID        ?= 5236CA08
 DEB_TOPDIR    = "/debbuild"

--- a/debs/bionic/fits/debian/patches/changehome.diff
+++ b/debs/bionic/fits/debian/patches/changehome.diff
@@ -2,7 +2,7 @@ Index: fits/fits-env.sh
 ===================================================================
 --- fits.orig/fits-env.sh
 +++ fits/fits-env.sh
-@@ -17,9 +17,10 @@ while [ -h "$FITS_ENV_SCRIPT" ] ; do
+@@ -17,7 +17,7 @@ while [ -h "$FITS_ENV_SCRIPT" ] ; do
    fi
  done
  
@@ -10,7 +10,4 @@ Index: fits/fits-env.sh
 +FITS_HOME="/usr/share/fits"
  
  export FITS_HOME
-+cd $FITS_HOME
- 
- # Uncomment the following line if you want "file utility" to dereference and follow symlinks.
- # export POSIXLY_CORRECT=1
+

--- a/debs/bionic/fits/debian/patches/fits-logging.diff
+++ b/debs/bionic/fits/debian/patches/fits-logging.diff
@@ -1,0 +1,12 @@
+Index: fits/fits.sh
+===================================================================
+--- fits.orig/fits.sh
++++ fits/fits.sh
+@@ -16,6 +16,6 @@ done
+ 
+ . "$(dirname $FITS_SCRIPT)/fits-env.sh"
+ 
+-cmd="java -classpath \"$APPCLASSPATH\" edu.harvard.hul.ois.fits.Fits $args"
++cmd="java -Dlog4j.configuration=file:\"$FITS_HOME\"/log4j.properties -classpath \"$APPCLASSPATH\" edu.harvard.hul.ois.fits.Fits $args"
+ 
+ eval "exec $cmd"

--- a/debs/bionic/fits/debian/patches/fits-ngserver-logging.diff
+++ b/debs/bionic/fits/debian/patches/fits-ngserver-logging.diff
@@ -1,0 +1,13 @@
+Index: fits/fits-ngserver.sh
+===================================================================
+--- fits.orig/fits-ngserver.sh
++++ fits/fits-ngserver.sh
+@@ -17,7 +17,7 @@ else
+ 	NAILGUN_JAR=$1
+ fi
+ 
+-cmd="java -classpath \"$APPCLASSPATH:$NAILGUN_JAR\" com.martiansoftware.nailgun.NGServer"
++cmd="java -Dlog4j.configuration=file:\"$FITS_HOME\"/log4j.properties -classpath \"$APPCLASSPATH:$NAILGUN_JAR\" com.martiansoftware.nailgun.NGServer"
+ 
+ echo "You may now run FITS by typing: ng edu.harvard.hul.ois.fits.Fits [options]" >&2
+ 

--- a/debs/bionic/fits/debian/patches/series
+++ b/debs/bionic/fits/debian/patches/series
@@ -2,3 +2,5 @@ archivematica-config.diff
 changehome.diff
 fits-log4j.diff
 fits-use-system-exitftool.diff
+fits-logging.diff
+fits-ngserver-logging.diff

--- a/debs/xenial/fits/Makefile
+++ b/debs/xenial/fits/Makefile
@@ -1,6 +1,6 @@
 NAME          = fits
 VERSION       ?= 1.1.0
-RELEASE	      ?= 1~16.04
+RELEASE	      ?= 2~16.04
 GIT_URL	      = https://github.com/harvard-lts/fits
 GPG_ID        ?= 5236CA08
 DEB_TOPDIR    = "/debbuild"

--- a/debs/xenial/fits/debian/patches/changehome.diff
+++ b/debs/xenial/fits/debian/patches/changehome.diff
@@ -2,7 +2,7 @@ Index: fits/fits-env.sh
 ===================================================================
 --- fits.orig/fits-env.sh
 +++ fits/fits-env.sh
-@@ -17,9 +17,10 @@ while [ -h "$FITS_ENV_SCRIPT" ] ; do
+@@ -17,7 +17,7 @@ while [ -h "$FITS_ENV_SCRIPT" ] ; do
    fi
  done
  
@@ -10,7 +10,4 @@ Index: fits/fits-env.sh
 +FITS_HOME="/usr/share/fits"
  
  export FITS_HOME
-+cd $FITS_HOME
- 
- # Uncomment the following line if you want "file utility" to dereference and follow symlinks.
- # export POSIXLY_CORRECT=1
+

--- a/debs/xenial/fits/debian/patches/fits-logging.diff
+++ b/debs/xenial/fits/debian/patches/fits-logging.diff
@@ -1,0 +1,12 @@
+Index: fits/fits.sh
+===================================================================
+--- fits.orig/fits.sh
++++ fits/fits.sh
+@@ -16,6 +16,6 @@ done
+ 
+ . "$(dirname $FITS_SCRIPT)/fits-env.sh"
+ 
+-cmd="java -classpath \"$APPCLASSPATH\" edu.harvard.hul.ois.fits.Fits $args"
++cmd="java -Dlog4j.configuration=file:\"$FITS_HOME\"/log4j.properties -classpath \"$APPCLASSPATH\" edu.harvard.hul.ois.fits.Fits $args"
+ 
+ eval "exec $cmd"

--- a/debs/xenial/fits/debian/patches/fits-ngserver-logging.diff
+++ b/debs/xenial/fits/debian/patches/fits-ngserver-logging.diff
@@ -1,0 +1,13 @@
+Index: fits/fits-ngserver.sh
+===================================================================
+--- fits.orig/fits-ngserver.sh
++++ fits/fits-ngserver.sh
+@@ -17,7 +17,7 @@ else
+ 	NAILGUN_JAR=$1
+ fi
+ 
+-cmd="java -classpath \"$APPCLASSPATH:$NAILGUN_JAR\" com.martiansoftware.nailgun.NGServer"
++cmd="java -Dlog4j.configuration=file:\"$FITS_HOME\"/log4j.properties -classpath \"$APPCLASSPATH:$NAILGUN_JAR\" com.martiansoftware.nailgun.NGServer"
+ 
+ echo "You may now run FITS by typing: ng edu.harvard.hul.ois.fits.Fits [options]" >&2
+ 

--- a/debs/xenial/fits/debian/patches/series
+++ b/debs/xenial/fits/debian/patches/series
@@ -2,3 +2,5 @@ archivematica-config.diff
 changehome.diff
 fits-log4j.diff
 fits-use-system-exitftool.diff
+fits-logging.diff
+fits-ngserver-logging.diff


### PR DESCRIPTION
This commit fixes an issue when using relative paths and defines the
log4j.configuration file directly in the java command for fits.sh and
fits-ngserver.sh.

Connects to archivematica/Issues#247