### PR TITLE
centos nailgun: Update to 0.9.3 version

### DIFF
--- a/rpm/nailgun/Makefile
+++ b/rpm/nailgun/Makefile
@@ -1,5 +1,5 @@
 NAME          = nailgun
-VERSION       = 0.9.1
+VERSION       = 0.9.3
 RPM_TOPDIR    = "/rpmbuild"
 DOCKER_VOLUME = "/src"
 DOCKER_IMAGE  = "rpmbuild-$(NAME)-$(VERSION)"
@@ -28,7 +28,8 @@ rpm-build: rpm-clean
 	cp $(DOCKER_VOLUME)/package.spec $(RPM_TOPDIR)/package.spec
 	yum-builddep -y maven gcc
 	mkdir -p $(RPM_TOPDIR)/SOURCES/
-	wget -O  $(RPM_TOPDIR)/SOURCES/master.zip https://github.com/martylamb/nailgun/archive/master.zip
+	wget -O  $(RPM_TOPDIR)/SOURCES/nailgun-all-0.9.3.zip https://github.com/facebook/nailgun/archive/nailgun-all-0.9.3.zip
+	cp files/* $(RPM_TOPDIR)/SOURCES/
 	rpmbuild $(RPMBUILD_ARGS) -ba --clean $(RPM_TOPDIR)/package.spec
 
 	@echo "==> Copying RPM files."

--- a/rpm/nailgun/files/change-client-name.patch
+++ b/rpm/nailgun/files/change-client-name.patch
@@ -1,0 +1,23 @@
+--- nailgun-client/ng.c-orig	2018-10-29 22:01:38.311627470 +0100
++++ nailgun-client/ng.c	2018-10-29 22:01:09.827125688 +0100
+@@ -81,7 +81,7 @@
+ #define NAILGUN_CLIENT_NAME_EXE "ng.exe"
+ 
+ #define NAILGUN_PORT_DEFAULT "2113"
+-#define NAILGUN_CLIENT_NAME "ng"
++#define NAILGUN_CLIENT_NAME "ng-nailgun"
+ #define CHUNK_HEADER_LEN (5)
+ 
+ #define NAILGUN_SOCKET_FAILED (231)
+@@ -622,9 +622,9 @@
+  */
+ void usage(int exitcode) {
+   fprintf(stderr, "NailGun v%s\n\n", NAILGUN_VERSION);
+-  fprintf(stderr, "Usage: ng class [--nailgun-options] [args]\n");
++  fprintf(stderr, "Usage: ng-nailgun class [--nailgun-options] [args]\n");
+   fprintf(stderr, "          (to execute a class)\n");
+-  fprintf(stderr, "   or: ng alias [--nailgun-options] [args]\n");
++  fprintf(stderr, "   or: ng-nailgun alias [--nailgun-options] [args]\n");
+   fprintf(stderr, "          (to execute an aliased class)\n");
+   fprintf(stderr, "   or: alias [--nailgun-options] [args]\n");
+   fprintf(stderr, "          (to execute an aliased class, where \"alias\"\n");

--- a/rpm/nailgun/files/makefile-change-client-name.patch
+++ b/rpm/nailgun/files/makefile-change-client-name.patch
@@ -1,0 +1,18 @@
+--- Makefile-orig	2018-10-29 21:57:47.231529852 +0100
++++ Makefile	2018-10-29 21:55:56.081451026 +0100
+@@ -13,7 +13,7 @@
+ 
+ ng: ${SRCDIR}/ng.c
+ 	@echo "Building ng client.  To build a Windows binary, type 'make ng.exe'"
+-	${CC} $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o ng ${SRCDIR}/ng.c
++	${CC} $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o ng-nailgun ${SRCDIR}/ng.c
+ 
+ install: ng
+ 	install -d ${PREFIX}/bin
+@@ -30,5 +30,5 @@
+ 	@echo "You must remove this manually.  Most users won't have MinGW"
+ 	@echo "installed - so I'd rather not delete something you can't rebuild."
+ 	@echo ""
+-	rm -f ng
++	rm -f ng-nailgun
+ #	rm -f ng.exe

--- a/rpm/nailgun/package.spec
+++ b/rpm/nailgun/package.spec
@@ -2,10 +2,11 @@ Name:    %{name}
 Version: %{version}
 Release: 1%{?dist}
 Summary: client, protocol, and server for running Java programs from CLI
-Buildrequires: maven, gcc
-Source: https://github.com/martylamb/nailgun/archive/master.zip
+Buildrequires: maven, gcc, java-devel, jpackage-utils, java-headless
+Source: https://github.com/facebook/nailgun/archive/nailgun-all-0.9.3.zip
 License: see /usr/share/doc/bagit-java/LICENSE.txt
-
+Patch: change-client-name.patch
+Patch1: makefile-change-client-name.patch
 
 %description
 Nailgun is a client, protocol, and server for running Java programs from
@@ -14,17 +15,20 @@ in the server (which is implemented in Java), and are triggered by the
 client (written in C), which handles all I/O.
 
 %files
-"/usr/bin/ng"
+"/usr/bin/ng-nailgun"
 "/usr/share/doc/nailgun/README.md"
 "/usr/share/doc/nailgun/LICENSE.txt"
 "/usr/share/nailgun/"
 
 %prep
 rm -rf %{buildroot}/*
-%setup -q -n nailgun-master
+%setup -q -n nailgun-nailgun-all-0.9.3
+
+%patch
+%patch1
 
 %install
-make
+make ng
 mvn package
 
 mkdir -p \
@@ -32,9 +36,11 @@ mkdir -p \
 	%{buildroot}/usr/share/doc/nailgun/ \
 	%{buildroot}/usr/share/nailgun/
 
-cp ng  %{buildroot}/usr/bin/
+cp ng-nailgun  %{buildroot}/usr/bin/
 cp LICENSE.txt README.md %{buildroot}/usr/share/doc/nailgun/
 cp nailgun-server/target/*.jar %{buildroot}/usr/share/nailgun/
 
-
 %changelog
+* Mon Oct 29 2018 - sysadmin@artefactual.com
+- bump version to 0.9.3
+- use ng-nailgun client name instead of ng

--- a/rpm/nailgun/package.spec
+++ b/rpm/nailgun/package.spec
@@ -40,7 +40,14 @@ cp ng-nailgun  %{buildroot}/usr/bin/
 cp LICENSE.txt README.md %{buildroot}/usr/share/doc/nailgun/
 cp nailgun-server/target/*.jar %{buildroot}/usr/share/nailgun/
 
+%post
+ln -s -f /usr/share/nailgun/nailgun-server-0.9.3-SNAPSHOT.jar /usr/share/nailgun/nailgun-server-latest-SNAPSHOT.jar
+
+%postun
+rm -f /usr/share/nailgun/nailgun-server-latest-SNAPSHOT.jar
+
 %changelog
 * Mon Oct 29 2018 - sysadmin@artefactual.com
 - bump version to 0.9.3
 - use ng-nailgun client name instead of ng
+- add nailgun-server-latest-SNAPSHOT.jar symlink


### PR DESCRIPTION
- bump version to 0.9.3
- use ng-nailgun client binary from Ubuntu Bionic package
- add symlink to latest SNAPSHOT.jar

Connects to https://github.com/archivematica/Issues/issues/247