### PR TITLE
centos fits: update systemd file for nailgun 0.9.3

### DIFF
--- a/rpm/fits/files/fits-nailgun.service
+++ b/rpm/fits/files/fits-nailgun.service
@@ -4,7 +4,7 @@ After=syslog.target network.target
 
 [Service]
 User=archivematica
-ExecStart=/usr/bin/fits-ngserver.sh /usr/share/nailgun/nailgun-server-0.9.3-SNAPSHOT.jar
+ExecStart=/usr/bin/fits-ngserver.sh /usr/share/nailgun/nailgun-server-latest-SNAPSHOT.jar
 Restart=always
 RestartSec=3
 

--- a/rpm/fits/files/fits-nailgun.service
+++ b/rpm/fits/files/fits-nailgun.service
@@ -4,7 +4,7 @@ After=syslog.target network.target
 
 [Service]
 User=archivematica
-ExecStart=/usr/bin/fits-ngserver.sh /usr/share/nailgun/nailgun-server-0.9.2-SNAPSHOT.jar
+ExecStart=/usr/bin/fits-ngserver.sh /usr/share/nailgun/nailgun-server-0.9.3-SNAPSHOT.jar
 Restart=always
 RestartSec=3
 

--- a/rpm/fits/package.spec
+++ b/rpm/fits/package.spec
@@ -1,7 +1,7 @@
 %global _default_patch_fuzz 2
 Name: %{name}
 Version: %{version}
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary: File Information Tool Set (FITS)
 Buildrequires: ant, gcc
 Source: https://github.com/harvard-lts/fits/archive/v%{version}.zip
@@ -62,3 +62,7 @@ touch /var/log/archivematica/fits.log
 chown archivematica.archivematica /var/log/archivematica/fits.log
 # TODO: reload only when the script changes. Check https://fedoraproject.org/wiki/Packaging:Scriptlets?rd=Packaging:ScriptletSnippets#Systemd
 systemctl daemon-reload
+
+%changelog
+* Tue Oct 30 2018 - sysadmin@artefactual.com
+- Update systemd init script for nailgun 0.9.3

--- a/rpm/fits/package.spec
+++ b/rpm/fits/package.spec
@@ -65,4 +65,6 @@ systemctl daemon-reload
 
 %changelog
 * Tue Oct 30 2018 - sysadmin@artefactual.com
-- Update systemd init script for nailgun 0.9.3
+- Update systemd init script to use nailgun-server-latest-SNAPSHOT.jar
+  symlink
+


### PR DESCRIPTION
After updating `nailgun` to 0.9.3 version, the systemd init script has to be updated to use the new jar file.

Connects to archivematica/Issues#247
Connects to https://github.com/artefactual-labs/am-packbuild/pull/198