### PR TITLE
deb fits: add fits-nailgun service

### DIFF
--- a/debs/bionic/fits/Makefile
+++ b/debs/bionic/fits/Makefile
@@ -1,6 +1,6 @@
 NAME          = fits
 VERSION       ?= 1.1.0
-RELEASE	      ?= 4~18.04
+RELEASE	      ?= 5~18.04
 GIT_URL	      = https://github.com/harvard-lts/fits
 GPG_ID        ?= 5236CA08
 DEB_TOPDIR    = "/debbuild"

--- a/debs/bionic/fits/debian/changelog
+++ b/debs/bionic/fits/debian/changelog
@@ -1,3 +1,9 @@
+fits (1.1.0-5~18.04) bionic; urgency=low
+
+  * Added systemd init script
+
+ -- Artefactual Sysadmin <sysadmin@artefactual.com>  Wed, 31 Oct 2018 10:25:11 -0800
+
 fits (0.8.4-1~14.04) trusty; urgency=low
 
   * New upstream release

--- a/debs/bionic/fits/debian/fits.fits-nailgun.service
+++ b/debs/bionic/fits/debian/fits.fits-nailgun.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=FITS Nailgun server
+After=syslog.target network.target
+
+[Service]
+User=archivematica
+ExecStart=/usr/bin/fits-ngserver.sh /usr/share/maven-repo/com/martiansoftware/nailgun-server/debian/nailgun-server-debian.jar
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target

--- a/debs/bionic/fits/debian/rules
+++ b/debs/bionic/fits/debian/rules
@@ -16,9 +16,15 @@
 override_dh_shlibdeps:
 
 %:
-	dh  $@
+	dh  $@ --with systemd
 
 override_dh_auto_build:
 	dh_auto_build -- compile-create-jar
+
+override_dh_installsystemd:
+	dh_installsystemd --name=fits-nailgun --restart-after-upgrade
+
+override_dh_systemd_enable:
+	dh_systemd_enable --name=fits-nailgun
 
 override_dh_strip_nondeterminism:

--- a/debs/xenial/fits/Makefile
+++ b/debs/xenial/fits/Makefile
@@ -1,6 +1,6 @@
 NAME          = fits
 VERSION       ?= 1.1.0
-RELEASE	      ?= 2~16.04
+RELEASE	      ?= 3~16.04
 GIT_URL	      = https://github.com/harvard-lts/fits
 GPG_ID        ?= 5236CA08
 DEB_TOPDIR    = "/debbuild"

--- a/debs/xenial/fits/debian/changelog
+++ b/debs/xenial/fits/debian/changelog
@@ -1,3 +1,9 @@
+fits (1.1.0-3~16.04) bionic; urgency=low
+
+  * Added systemd init script
+
+ -- Artefactual Sysadmin <sysadmin@artefactual.com>  Wed, 31 Oct 2018 10:25:11 -0800
+
 fits (0.8.4-1~14.04) trusty; urgency=low
 
   * New upstream release

--- a/debs/xenial/fits/debian/control
+++ b/debs/xenial/fits/debian/control
@@ -2,7 +2,7 @@ Source: fits
 Section: utils
 Priority: extra
 Maintainer: austin trask <austin@artefactual.com>
-Build-Depends: debhelper (>= 7), default-jdk, ant-gcj
+Build-Depends: debhelper (>= 7), default-jdk, ant-gcj, dh-systemd
 Standards-Version: 3.8.3
 Homepage: http://code.google.com/p/fits/
 

--- a/debs/xenial/fits/debian/fits.fits-nailgun.service
+++ b/debs/xenial/fits/debian/fits.fits-nailgun.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=FITS Nailgun server
+After=syslog.target network.target
+
+[Service]
+User=archivematica
+ExecStart=/usr/bin/fits-ngserver.sh /usr/share/maven-repo/com/martiansoftware/nailgun-server/debian/nailgun-server-debian.jar
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target

--- a/debs/xenial/fits/debian/rules
+++ b/debs/xenial/fits/debian/rules
@@ -16,9 +16,15 @@
 override_dh_shlibdeps:
 
 %:
-	dh  $@
+	dh  $@ --with systemd
 
 override_dh_auto_build:
 	dh_auto_build -- compile-create-jar
+
+override_dh_installsystemd:
+	dh_installsystemd --name=fits-nailgun --restart-after-upgrade
+
+override_dh_systemd_enable:
+	dh_systemd_enable --name=fits-nailgun
 
 override_dh_strip_nondeterminism:


### PR DESCRIPTION
This commit adds the systemd init script for the fits-nailgun service.

Connects to https://github.com/archivematica/Issues/issues/310