### PR TITLE
jenkisci: Use qa/1.x as am-packbuild branch

### DIFF
--- a/debs/bionic/.Jenkinsci
+++ b/debs/bionic/.Jenkinsci
@@ -6,7 +6,7 @@ parameters([
   string(defaultValue: '0F4A4D31', description: 'For production packages, use production key', name: 'GPG_ID'),
   string(defaultValue: '1.8.0', description: '', name: 'VERSION'),
   string(defaultValue: '-beta1', description: '', name: 'RELEASE'),
-  string(defaultValue: 'dev/packages-ci', description: '', name: 'PACKBUILD_BRANCH'),
+  string(defaultValue: 'qa/1.x', description: '', name: 'PACKBUILD_BRANCH'),
   string(defaultValue: 'jenkinsci', description: '', name: 'REPOSITORY')]),
   pipelineTriggers([])])
 

--- a/debs/xenial/.Jenkinsci
+++ b/debs/xenial/.Jenkinsci
@@ -6,7 +6,7 @@ parameters([
   string(defaultValue: '0F4A4D31', description: 'For production packages, use production key', name: 'GPG_ID'),
   string(defaultValue: '1.8.0', description: '', name: 'VERSION'),
   string(defaultValue: '-beta1', description: '', name: 'RELEASE'),
-  string(defaultValue: 'dev/packages-ci', description: '', name: 'PACKBUILD_BRANCH'),
+  string(defaultValue: 'qa/1.x', description: '', name: 'PACKBUILD_BRANCH'),
   string(defaultValue: 'jenkinsci', description: '', name: 'REPOSITORY')]),
   pipelineTriggers([])])
 

--- a/rpm/.Jenkinsci
+++ b/rpm/.Jenkinsci
@@ -6,7 +6,7 @@ parameters([
   string(defaultValue: '0F4A4D31', description: 'For production packages, use production key', name: 'GPG_ID'),
   string(defaultValue: '1.8.0', description: '', name: 'VERSION'),
   string(defaultValue: 'beta1', description: '', name: 'RELEASE'),
-  string(defaultValue: 'dev/packages-ci', description: '', name: 'PACKBUILD_BRANCH'),
+  string(defaultValue: 'qa/1.x', description: '', name: 'PACKBUILD_BRANCH'),
   string(defaultValue: 'jenkinsci', description: '', name: 'REPOSITORY')]),
   pipelineTriggers([])])
 


### PR DESCRIPTION
Use `qa/1.x` as default `am-packbuild` branch for jenkinsci jobs instead of `dev/packages-ci`