### PR TITLE
am: Add --clear option to collectstatic commands

### DIFF
--- a/debs/bionic/archivematica-storage-service/Makefile
+++ b/debs/bionic/archivematica-storage-service/Makefile
@@ -9,7 +9,7 @@ PACKBUILD_EXTRA_ARGS ?=
 PACKAGE = archivematica-storage-service
 BRANCH     ?= qa/0.x
 VERSION     ?= 0.13.0
-RELEASE       ?= +beta1
+RELEASE       ?= -2
 BUILD_TYPE         ?= ss
 
 .PHONY: build-docker-image build deb-build deb-clean deb-test update-changelog

--- a/debs/bionic/archivematica-storage-service/debian-storage-service/postinst
+++ b/debs/bionic/archivematica-storage-service/debian-storage-service/postinst
@@ -55,7 +55,7 @@ if [[ $2 == '1:0.7.'* ]]; then
 fi
 
 ${SS_ENV_DIR}/bin/python manage.py migrate
-${SS_ENV_DIR}/bin/python manage.py collectstatic --noinput
+${SS_ENV_DIR}/bin/python manage.py collectstatic --noinput --clear
 ${SS_ENV_DIR}/bin/python manage.py backfill_api_keys
 
 echo "updating directory permissions"

--- a/debs/bionic/archivematica/Makefile
+++ b/debs/bionic/archivematica/Makefile
@@ -8,7 +8,7 @@ PACKBUILD_EXTRA_ARGS ?=
 #PACKBUILD_EXTRA_ARGS ?= "-b 1"
 BRANCH     ?= qa/1.x
 VERSION     ?= 1.8.0
-RELEASE       ?= +beta1
+RELEASE       ?= -2
 BUILD_TYPE         ?= am
 
 .PHONY: build-docker-image build deb-build deb-clean deb-test update-changelog

--- a/debs/bionic/archivematica/debian-dashboard/postinst
+++ b/debs/bionic/archivematica/debian-dashboard/postinst
@@ -48,7 +48,7 @@ fi
 /usr/share/archivematica/dashboard/manage.py migrate --settings='settings.production'
 
 # Collect static content
-/usr/share/archivematica/dashboard/manage.py collectstatic --noinput
+/usr/share/archivematica/dashboard/manage.py collectstatic --noinput --clear
 
 
 #DEBHELPER#

--- a/debs/xenial/archivematica-storage-service/Makefile
+++ b/debs/xenial/archivematica-storage-service/Makefile
@@ -7,9 +7,9 @@ GPG_ID ?= 0F4A4D31
 PACKBUILD_EXTRA_ARGS ?= 
 #PACKBUILD_EXTRA_ARGS ?= "-b 1"
 PACKAGE = archivematica-storage-service
-BRANCH     ?= stable/0.11.x
-VERSION     ?= 0.11.0
-RELEASE       ?= +rc2~xenial
+BRANCH     ?= qa/0.x
+VERSION     ?= 0.13.0
+RELEASE       ?= -2
 BUILD_TYPE         ?= ss
 
 .PHONY: build-docker-image build deb-build deb-clean deb-test update-changelog

--- a/debs/xenial/archivematica-storage-service/debian-storage-service/postinst
+++ b/debs/xenial/archivematica-storage-service/debian-storage-service/postinst
@@ -55,7 +55,7 @@ if [[ $2 == '1:0.7.'* ]]; then
 fi
 
 ${SS_ENV_DIR}/bin/python manage.py migrate
-${SS_ENV_DIR}/bin/python manage.py collectstatic --noinput
+${SS_ENV_DIR}/bin/python manage.py collectstatic --noinput --clear
 ${SS_ENV_DIR}/bin/python manage.py backfill_api_keys
 
 echo "updating directory permissions"

--- a/debs/xenial/archivematica/Makefile
+++ b/debs/xenial/archivematica/Makefile
@@ -6,9 +6,9 @@ DOCKER_IMAGE  = "debbuild-$(NAME)-$(VERSION)"
 GPG_ID ?= 0F4A4D31
 PACKBUILD_EXTRA_ARGS ?= 
 #PACKBUILD_EXTRA_ARGS ?= "-b 1"
-BRANCH     ?= stable/1.7.x
-VERSION     ?= 1.7.0
-RELEASE       ?= +rc1~xenial
+BRANCH     ?= qa/1.x
+VERSION     ?= 1.8.0
+RELEASE       ?= -2
 BUILD_TYPE         ?= am
 
 .PHONY: build-docker-image build deb-build deb-clean deb-test update-changelog

--- a/debs/xenial/archivematica/debian-dashboard/postinst
+++ b/debs/xenial/archivematica/debian-dashboard/postinst
@@ -48,7 +48,7 @@ fi
 /usr/share/archivematica/dashboard/manage.py migrate --settings='settings.production'
 
 # Collect static content
-/usr/share/archivematica/dashboard/manage.py collectstatic --noinput
+/usr/share/archivematica/dashboard/manage.py collectstatic --noinput --clear
 
 
 #DEBHELPER#

--- a/rpm/archivematica-storage-service/Makefile
+++ b/rpm/archivematica-storage-service/Makefile
@@ -1,7 +1,7 @@
 NAME          = archivematica-storage-service
-BRANCH        ?= stable/0.11.x
-VERSION       ?= 0.11.0
-RELEASE       ?= rc1
+BRANCH        ?= qa/1.x
+VERSION       ?= 0.13.0
+RELEASE       ?= 2
 RPM_TOPDIR    = "/rpmbuild"
 DOCKER_VOLUME = "/src"
 DOCKER_IMAGE  = $(subst ~,-,"rpmbuild-$(NAME)-$(VERSION)")

--- a/rpm/archivematica-storage-service/package.spec
+++ b/rpm/archivematica-storage-service/package.spec
@@ -102,7 +102,7 @@ sed -i "s/<replace-with-key>/\"$KEYCMD\"/g" /etc/sysconfig/archivematica-storage
 # Run django collectstatic task
 cd /usr/lib/archivematica/storage-service
 export $(cat /etc/sysconfig/archivematica-storage-service)
-/usr/share/archivematica/virtualenvs/archivematica-storage-service/bin/python manage.py collectstatic --noinput
+/usr/share/archivematica/virtualenvs/archivematica-storage-service/bin/python manage.py collectstatic --noinput --clear
 
 systemctl daemon-reload
 
@@ -113,4 +113,8 @@ fi
 if [ x$(semanage port -l | grep http_port_t | grep 8001 | wc -l) == x0 ]; then
   semanage port -a -t http_port_t -p tcp 8001
 fi
+
+%changelog
+* Tue Dec 11 2018 - sysadmin@artefactual.com
+- Update collectstatic command: added --clear option
 

--- a/rpm/archivematica/Makefile
+++ b/rpm/archivematica/Makefile
@@ -3,9 +3,9 @@ RPM_TOPDIR    = "/rpmbuild"
 DOCKER_VOLUME = "/src"
 DOCKER_IMAGE  ?= $(subst ~,-,"rpmbuild-$(NAME)-$(VERSION)")
 
-BRANCH     ?= stable/1.7.x
-VERSION     ?= 1.7.0
-RELEASE       ?= rc1
+BRANCH     ?= qa/1.x
+VERSION     ?= 1.8.0
+RELEASE       ?= 2
 
 RPMBUILD_ARGS := \
 	--define "_topdir $(RPM_TOPDIR)" \

--- a/rpm/archivematica/archivematica.spec
+++ b/rpm/archivematica/archivematica.spec
@@ -270,7 +270,7 @@ sed -i "s/CHANGE_ME_WITH_A_SECRET_KEY/\"$KEY\"/g" /etc/sysconfig/archivematica-d
 # Run django collectstatic
 export $(cat /etc/sysconfig/archivematica-dashboard)
 cd /usr/share/archivematica/dashboard
-/usr/share/archivematica/virtualenvs/archivematica-dashboard/bin/python manage.py collectstatic --noinput
+/usr/share/archivematica/virtualenvs/archivematica-dashboard/bin/python manage.py collectstatic --noinput --clear
 
 chown -R archivematica:archivematica /var/log/archivematica/dashboard
 systemctl daemon-reload
@@ -279,4 +279,7 @@ if [ x$(semanage port -l | grep http_port_t | grep 7400 | wc -l) == x0 ]; then
   semanage port -a -t http_port_t -p tcp 7400
 fi
 
+%changelog
+* Tue Dec 11 2018 - sysadmin@artefactual.com
+- Update collectstatic command: added --clear option
 


### PR DESCRIPTION
This option has been added to fix an issue upgrading from AM v1.7.2 to
AM v1.8.0. Because this option is safe and is useful in order to remove
stale static files, it has been added to the Archivematica Dashboard and
Archivematica Storage Service packages.

Connects to https://github.com/archivematica/Issues/issues/360