### PR TITLE
deb bionic: Fix SS last changelog to v0.13.0

### DIFF
--- a/debs/bionic/archivematica-storage-service/debian-storage-service/changelog
+++ b/debs/bionic/archivematica-storage-service/debian-storage-service/changelog
@@ -1,9 +1,9 @@
-archivematica-storage-service (1:1.8.0-1~18.04) bionic; urgency=high
+archivematica-storage-service (1:0.13.0-1~18.04) bionic; urgency=high
 
   * commit: 8863492193a8f07e89fa6f1a27ad9889be4de822
   * checkout: v0.13.0
 
- -- Artefactual Systems <sysadmin@artefactual.com>  Tue, 20 Nov 2018 00:26:39 +0000
+ -- Artefactual Systems <sysadmin@artefactual.com>  Tue, 20 Nov 2018 09:30:11 +0000
 
 archivematica-storage-service (1:0.12.0-1~16.04) xenial; urgency=high
 


### PR DESCRIPTION
The package archivematica-storage-service_1.8.0-1~18.04_amd64.deb was
created by error, and used its changelog instead of the v0.13.0 package.

Connects to https://github.com/archivematica/Issues/issues/397