### PR TITLE
dashboard, ss postinst: Create collectstatic dir

### DIFF
--- a/debs/bionic/archivematica-storage-service/Makefile
+++ b/debs/bionic/archivematica-storage-service/Makefile
@@ -9,7 +9,7 @@ PACKBUILD_EXTRA_ARGS ?=
 PACKAGE = archivematica-storage-service
 BRANCH     ?= qa/0.x
 VERSION     ?= 0.13.0
-RELEASE       ?= -2
+RELEASE       ?= -3
 BUILD_TYPE         ?= ss
 
 .PHONY: build-docker-image build deb-build deb-clean deb-test update-changelog

--- a/debs/bionic/archivematica-storage-service/debian-storage-service/postinst
+++ b/debs/bionic/archivematica-storage-service/debian-storage-service/postinst
@@ -55,6 +55,7 @@ if [[ $2 == '1:0.7.'* ]]; then
 fi
 
 ${SS_ENV_DIR}/bin/python manage.py migrate
+mkdir -p /usr/lib/archivematica/storage-service/assets
 ${SS_ENV_DIR}/bin/python manage.py collectstatic --noinput --clear
 ${SS_ENV_DIR}/bin/python manage.py backfill_api_keys
 

--- a/debs/bionic/archivematica/Makefile
+++ b/debs/bionic/archivematica/Makefile
@@ -7,8 +7,8 @@ GPG_ID ?= 0F4A4D31
 PACKBUILD_EXTRA_ARGS ?= 
 #PACKBUILD_EXTRA_ARGS ?= "-b 1"
 BRANCH     ?= qa/1.x
-VERSION     ?= 1.8.0
-RELEASE       ?= -2
+VERSION     ?= 1.8.1
+RELEASE       ?= -1
 BUILD_TYPE         ?= am
 
 .PHONY: build-docker-image build deb-build deb-clean deb-test update-changelog

--- a/debs/bionic/archivematica/debian-dashboard/postinst
+++ b/debs/bionic/archivematica/debian-dashboard/postinst
@@ -48,6 +48,7 @@ fi
 /usr/share/archivematica/dashboard/manage.py migrate --settings='settings.production'
 
 # Collect static content
+mkdir -p /usr/share/archivematica/dashboard/static
 /usr/share/archivematica/dashboard/manage.py collectstatic --noinput --clear
 
 

--- a/debs/xenial/archivematica-storage-service/Makefile
+++ b/debs/xenial/archivematica-storage-service/Makefile
@@ -9,7 +9,7 @@ PACKBUILD_EXTRA_ARGS ?=
 PACKAGE = archivematica-storage-service
 BRANCH     ?= qa/0.x
 VERSION     ?= 0.13.0
-RELEASE       ?= -2
+RELEASE       ?= -3
 BUILD_TYPE         ?= ss
 
 .PHONY: build-docker-image build deb-build deb-clean deb-test update-changelog

--- a/debs/xenial/archivematica-storage-service/debian-storage-service/postinst
+++ b/debs/xenial/archivematica-storage-service/debian-storage-service/postinst
@@ -55,6 +55,7 @@ if [[ $2 == '1:0.7.'* ]]; then
 fi
 
 ${SS_ENV_DIR}/bin/python manage.py migrate
+mkdir -p /usr/lib/archivematica/storage-service/assets
 ${SS_ENV_DIR}/bin/python manage.py collectstatic --noinput --clear
 ${SS_ENV_DIR}/bin/python manage.py backfill_api_keys
 

--- a/debs/xenial/archivematica/Makefile
+++ b/debs/xenial/archivematica/Makefile
@@ -7,8 +7,8 @@ GPG_ID ?= 0F4A4D31
 PACKBUILD_EXTRA_ARGS ?= 
 #PACKBUILD_EXTRA_ARGS ?= "-b 1"
 BRANCH     ?= qa/1.x
-VERSION     ?= 1.8.0
-RELEASE       ?= -2
+VERSION     ?= 1.8.1
+RELEASE       ?= -1
 BUILD_TYPE         ?= am
 
 .PHONY: build-docker-image build deb-build deb-clean deb-test update-changelog

--- a/debs/xenial/archivematica/debian-dashboard/postinst
+++ b/debs/xenial/archivematica/debian-dashboard/postinst
@@ -48,6 +48,7 @@ fi
 /usr/share/archivematica/dashboard/manage.py migrate --settings='settings.production'
 
 # Collect static content
+mkdir -p /usr/share/archivematica/dashboard/static
 /usr/share/archivematica/dashboard/manage.py collectstatic --noinput --clear
 
 

--- a/rpm/archivematica-storage-service/Makefile
+++ b/rpm/archivematica-storage-service/Makefile
@@ -1,7 +1,7 @@
 NAME          = archivematica-storage-service
 BRANCH        ?= qa/1.x
 VERSION       ?= 0.13.0
-RELEASE       ?= 2
+RELEASE       ?= 3
 RPM_TOPDIR    = "/rpmbuild"
 DOCKER_VOLUME = "/src"
 DOCKER_IMAGE  = $(subst ~,-,"rpmbuild-$(NAME)-$(VERSION)")

--- a/rpm/archivematica-storage-service/package.spec
+++ b/rpm/archivematica-storage-service/package.spec
@@ -102,6 +102,7 @@ sed -i "s/<replace-with-key>/\"$KEYCMD\"/g" /etc/sysconfig/archivematica-storage
 # Run django collectstatic task
 cd /usr/lib/archivematica/storage-service
 export $(cat /etc/sysconfig/archivematica-storage-service)
+mkdir -p /usr/lib/archivematica/storage-service/assets
 /usr/share/archivematica/virtualenvs/archivematica-storage-service/bin/python manage.py collectstatic --noinput --clear
 
 systemctl daemon-reload
@@ -115,6 +116,7 @@ if [ x$(semanage port -l | grep http_port_t | grep 8001 | wc -l) == x0 ]; then
 fi
 
 %changelog
+* Wed Jan 09 2019 - sysadmin@artefactual.com
+- Create collectstatic directory in post script
 * Tue Dec 11 2018 - sysadmin@artefactual.com
 - Update collectstatic command: added --clear option
-

--- a/rpm/archivematica/Makefile
+++ b/rpm/archivematica/Makefile
@@ -4,8 +4,8 @@ DOCKER_VOLUME = "/src"
 DOCKER_IMAGE  ?= $(subst ~,-,"rpmbuild-$(NAME)-$(VERSION)")
 
 BRANCH     ?= qa/1.x
-VERSION     ?= 1.8.0
-RELEASE       ?= 2
+VERSION     ?= 1.8.1
+RELEASE       ?= 1
 
 RPMBUILD_ARGS := \
 	--define "_topdir $(RPM_TOPDIR)" \

--- a/rpm/archivematica/archivematica.spec
+++ b/rpm/archivematica/archivematica.spec
@@ -268,6 +268,7 @@ KEY=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
 sed -i "s/CHANGE_ME_WITH_A_SECRET_KEY/\"$KEY\"/g" /etc/sysconfig/archivematica-dashboard
 
 # Run django collectstatic
+mkdir -p /usr/share/archivematica/dashboard/static
 export $(cat /etc/sysconfig/archivematica-dashboard)
 cd /usr/share/archivematica/dashboard
 /usr/share/archivematica/virtualenvs/archivematica-dashboard/bin/python manage.py collectstatic --noinput --clear
@@ -280,6 +281,8 @@ if [ x$(semanage port -l | grep http_port_t | grep 7400 | wc -l) == x0 ]; then
 fi
 
 %changelog
+* Wed Jan 09 2019 - sysadmin@artefactual.com
+- Create collectstatic directory in post script
 * Tue Dec 11 2018 - sysadmin@artefactual.com
 - Update collectstatic command: added --clear option
 


### PR DESCRIPTION
When running the `collectstatic` command with the `--clear` option, the
following directories are needed:

* /usr/share/archivematica/dashboard/static
* /usr/lib/archivematica/storage-service/assets

The `--clear` option deletes the directory and it fails when the
directory doesn't exist, for example on fresh installations.

Connects to https://github.com/archivematica/Issues/issues/413