### PR TITLE
debs: Export LC_ALL var on debian/rules files

### DIFF
--- a/debs/bionic/archivematica-storage-service/debian-storage-service/rules
+++ b/debs/bionic/archivematica-storage-service/debian-storage-service/rules
@@ -1,5 +1,6 @@
 #!/usr/bin/make -f
 
+export LC_ALL=C.UTF-8
 export DH_VIRTUALENV_INSTALL_ROOT=/usr/share/archivematica/virtualenvs
 
 %:

--- a/debs/bionic/archivematica/debian-MCPClient/rules
+++ b/debs/bionic/archivematica/debian-MCPClient/rules
@@ -1,5 +1,6 @@
 #!/usr/bin/make -f
 
+export LC_ALL=C.UTF-8
 export DH_VIRTUALENV_INSTALL_ROOT=/usr/share/archivematica/virtualenvs
 
 %:

--- a/debs/bionic/archivematica/debian-MCPServer/rules
+++ b/debs/bionic/archivematica/debian-MCPServer/rules
@@ -1,5 +1,6 @@
 #!/usr/bin/make -f
 
+export LC_ALL=C.UTF-8
 export DH_VIRTUALENV_INSTALL_ROOT=/usr/share/archivematica/virtualenvs
 
 %:

--- a/debs/bionic/archivematica/debian-archivematicaCommon/rules
+++ b/debs/bionic/archivematica/debian-archivematicaCommon/rules
@@ -9,6 +9,7 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
+export LC_ALL=C.UTF-8
 export DH_VIRTUALENV_INSTALL_ROOT=/usr/share/archivematica/virtualenvs
 
 %:

--- a/debs/bionic/archivematica/debian-dashboard/rules
+++ b/debs/bionic/archivematica/debian-dashboard/rules
@@ -1,5 +1,6 @@
 #!/usr/bin/make -f
 
+export LC_ALL=C.UTF-8
 export DH_VIRTUALENV_INSTALL_ROOT=/usr/share/archivematica/virtualenvs
 
 %:

--- a/debs/xenial/archivematica-storage-service/debian-storage-service/rules
+++ b/debs/xenial/archivematica-storage-service/debian-storage-service/rules
@@ -1,5 +1,6 @@
 #!/usr/bin/make -f
 
+export LC_ALL=C.UTF-8
 export DH_VIRTUALENV_INSTALL_ROOT=/usr/share/archivematica/virtualenvs
 
 %:

--- a/debs/xenial/archivematica/debian-MCPClient/rules
+++ b/debs/xenial/archivematica/debian-MCPClient/rules
@@ -1,5 +1,6 @@
 #!/usr/bin/make -f
 
+export LC_ALL=C.UTF-8
 export DH_VIRTUALENV_INSTALL_ROOT=/usr/share/archivematica/virtualenvs
 
 %:

--- a/debs/xenial/archivematica/debian-MCPServer/rules
+++ b/debs/xenial/archivematica/debian-MCPServer/rules
@@ -1,5 +1,6 @@
 #!/usr/bin/make -f
 
+export LC_ALL=C.UTF-8
 export DH_VIRTUALENV_INSTALL_ROOT=/usr/share/archivematica/virtualenvs
 
 %:

--- a/debs/xenial/archivematica/debian-archivematicaCommon/rules
+++ b/debs/xenial/archivematica/debian-archivematicaCommon/rules
@@ -9,6 +9,7 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
+export LC_ALL=C.UTF-8
 export DH_VIRTUALENV_INSTALL_ROOT=/usr/share/archivematica/virtualenvs
 
 %:

--- a/debs/xenial/archivematica/debian-dashboard/rules
+++ b/debs/xenial/archivematica/debian-dashboard/rules
@@ -1,5 +1,6 @@
 #!/usr/bin/make -f
 
+export LC_ALL=C.UTF-8
 export DH_VIRTUALENV_INSTALL_ROOT=/usr/share/archivematica/virtualenvs
 
 %:


### PR DESCRIPTION
This is a recomendation from Debian when building python packages:

https://www.debian.org/doc/manuals/debmake-doc/ch07.en.html#utf-8-build

Connects to [archivematica/Issues#499](https://github.com/archivematica/Issues/issues/499)