### PR TITLE
Update 1.8.x branch with some qa commits

### DIFF
--- a/debs/bionic/archivematica-storage-service/Makefile
+++ b/debs/bionic/archivematica-storage-service/Makefile
@@ -9,7 +9,7 @@ PACKBUILD_EXTRA_ARGS ?=
 PACKAGE = archivematica-storage-service
 BRANCH     ?= qa/0.x
 VERSION     ?= 0.13.0
-RELEASE       ?= -2
+RELEASE       ?= -3
 BUILD_TYPE         ?= ss
 
 .PHONY: build-docker-image build deb-build deb-clean deb-test update-changelog

--- a/debs/bionic/archivematica-storage-service/Makefile
+++ b/debs/bionic/archivematica-storage-service/Makefile
@@ -9,7 +9,7 @@ PACKBUILD_EXTRA_ARGS ?=
 PACKAGE = archivematica-storage-service
 BRANCH     ?= qa/0.x
 VERSION     ?= 0.13.0
-RELEASE       ?= +beta1
+RELEASE       ?= -2
 BUILD_TYPE         ?= ss
 
 .PHONY: build-docker-image build deb-build deb-clean deb-test update-changelog

--- a/debs/bionic/archivematica-storage-service/debian-storage-service/changelog
+++ b/debs/bionic/archivematica-storage-service/debian-storage-service/changelog
@@ -1,9 +1,9 @@
-archivematica-storage-service (1:1.8.0-1~18.04) bionic; urgency=high
+archivematica-storage-service (1:0.13.0-1~18.04) bionic; urgency=high
 
   * commit: 8863492193a8f07e89fa6f1a27ad9889be4de822
   * checkout: v0.13.0
 
- -- Artefactual Systems <sysadmin@artefactual.com>  Tue, 20 Nov 2018 00:26:39 +0000
+ -- Artefactual Systems <sysadmin@artefactual.com>  Tue, 20 Nov 2018 09:30:11 +0000
 
 archivematica-storage-service (1:0.12.0-1~16.04) xenial; urgency=high
 

--- a/debs/bionic/archivematica-storage-service/debian-storage-service/postinst
+++ b/debs/bionic/archivematica-storage-service/debian-storage-service/postinst
@@ -55,6 +55,7 @@ if [[ $2 == '1:0.7.'* ]]; then
 fi
 
 ${SS_ENV_DIR}/bin/python manage.py migrate
+mkdir -p /usr/lib/archivematica/storage-service/assets
 ${SS_ENV_DIR}/bin/python manage.py collectstatic --noinput --clear
 ${SS_ENV_DIR}/bin/python manage.py backfill_api_keys
 

--- a/debs/bionic/archivematica-storage-service/debian-storage-service/postinst
+++ b/debs/bionic/archivematica-storage-service/debian-storage-service/postinst
@@ -55,7 +55,7 @@ if [[ $2 == '1:0.7.'* ]]; then
 fi
 
 ${SS_ENV_DIR}/bin/python manage.py migrate
-${SS_ENV_DIR}/bin/python manage.py collectstatic --noinput
+${SS_ENV_DIR}/bin/python manage.py collectstatic --noinput --clear
 ${SS_ENV_DIR}/bin/python manage.py backfill_api_keys
 
 echo "updating directory permissions"

--- a/debs/bionic/archivematica/Makefile
+++ b/debs/bionic/archivematica/Makefile
@@ -8,7 +8,7 @@ PACKBUILD_EXTRA_ARGS ?=
 #PACKBUILD_EXTRA_ARGS ?= "-b 1"
 BRANCH     ?= qa/1.x
 VERSION     ?= 1.8.0
-RELEASE       ?= +beta1
+RELEASE       ?= -2
 BUILD_TYPE         ?= am
 
 .PHONY: build-docker-image build deb-build deb-clean deb-test update-changelog

--- a/debs/bionic/archivematica/Makefile
+++ b/debs/bionic/archivematica/Makefile
@@ -7,8 +7,8 @@ GPG_ID ?= 0F4A4D31
 PACKBUILD_EXTRA_ARGS ?= 
 #PACKBUILD_EXTRA_ARGS ?= "-b 1"
 BRANCH     ?= qa/1.x
-VERSION     ?= 1.8.0
-RELEASE       ?= -2
+VERSION     ?= 1.8.1
+RELEASE       ?= -1
 BUILD_TYPE         ?= am
 
 .PHONY: build-docker-image build deb-build deb-clean deb-test update-changelog

--- a/debs/bionic/archivematica/debian-MCPClient/changelog
+++ b/debs/bionic/archivematica/debian-MCPClient/changelog
@@ -1,3 +1,10 @@
+archivematica-mcp-client (1:1.8.1-1~18.04) bionic; urgency=high
+
+  * commit: e240825332b76f3cc50b66646921fd9b1ab84d4b
+  * checkout: v1.8.1
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Wed, 09 Jan 2019 18:04:25 +0000
+
 archivematica-mcp-client (1:1.8.0-1~18.04) bionic; urgency=high
 
   * commit: 707e9332f0bebf4c32def012e30752314a207d48

--- a/debs/bionic/archivematica/debian-MCPServer/changelog
+++ b/debs/bionic/archivematica/debian-MCPServer/changelog
@@ -1,3 +1,10 @@
+archivematica-mcp-server (1:1.8.1-1~18.04) bionic; urgency=high
+
+  * commit: e240825332b76f3cc50b66646921fd9b1ab84d4b
+  * checkout: v1.8.1
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Wed, 09 Jan 2019 18:10:20 +0000
+
 archivematica-mcp-server (1:1.8.0-1~18.04) bionic; urgency=high
 
   * commit: 707e9332f0bebf4c32def012e30752314a207d48

--- a/debs/bionic/archivematica/debian-archivematicaCommon/changelog
+++ b/debs/bionic/archivematica/debian-archivematicaCommon/changelog
@@ -1,3 +1,10 @@
+archivematica-common (1:1.8.1-1~18.04) bionic; urgency=high
+
+  * commit: e240825332b76f3cc50b66646921fd9b1ab84d4b
+  * checkout: v1.8.1
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Wed, 09 Jan 2019 18:15:20 +0000
+
 archivematica-common (1:1.8.0-1~18.04) bionic; urgency=high
 
   * commit: 707e9332f0bebf4c32def012e30752314a207d48

--- a/debs/bionic/archivematica/debian-dashboard/changelog
+++ b/debs/bionic/archivematica/debian-dashboard/changelog
@@ -1,3 +1,10 @@
+archivematica-dashboard (1:1.8.1-1~18.04) bionic; urgency=high
+
+  * commit: e240825332b76f3cc50b66646921fd9b1ab84d4b
+  * checkout: v1.8.1
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Wed, 09 Jan 2019 17:47:39 +0000
+
 archivematica-dashboard (1:1.8.0-1~18.04) bionic; urgency=high
 
   * commit: 707e9332f0bebf4c32def012e30752314a207d48

--- a/debs/bionic/archivematica/debian-dashboard/postinst
+++ b/debs/bionic/archivematica/debian-dashboard/postinst
@@ -48,7 +48,7 @@ fi
 /usr/share/archivematica/dashboard/manage.py migrate --settings='settings.production'
 
 # Collect static content
-/usr/share/archivematica/dashboard/manage.py collectstatic --noinput
+/usr/share/archivematica/dashboard/manage.py collectstatic --noinput --clear
 
 
 #DEBHELPER#

--- a/debs/bionic/archivematica/debian-dashboard/postinst
+++ b/debs/bionic/archivematica/debian-dashboard/postinst
@@ -48,6 +48,7 @@ fi
 /usr/share/archivematica/dashboard/manage.py migrate --settings='settings.production'
 
 # Collect static content
+mkdir -p /usr/share/archivematica/dashboard/static
 /usr/share/archivematica/dashboard/manage.py collectstatic --noinput --clear
 
 

--- a/debs/xenial/archivematica-storage-service/Makefile
+++ b/debs/xenial/archivematica-storage-service/Makefile
@@ -9,7 +9,7 @@ PACKBUILD_EXTRA_ARGS ?=
 PACKAGE = archivematica-storage-service
 BRANCH     ?= qa/0.x
 VERSION     ?= 0.13.0
-RELEASE       ?= -2
+RELEASE       ?= -3
 BUILD_TYPE         ?= ss
 
 .PHONY: build-docker-image build deb-build deb-clean deb-test update-changelog

--- a/debs/xenial/archivematica-storage-service/Makefile
+++ b/debs/xenial/archivematica-storage-service/Makefile
@@ -7,9 +7,9 @@ GPG_ID ?= 0F4A4D31
 PACKBUILD_EXTRA_ARGS ?= 
 #PACKBUILD_EXTRA_ARGS ?= "-b 1"
 PACKAGE = archivematica-storage-service
-BRANCH     ?= stable/0.11.x
-VERSION     ?= 0.11.0
-RELEASE       ?= +rc2~xenial
+BRANCH     ?= qa/0.x
+VERSION     ?= 0.13.0
+RELEASE       ?= -2
 BUILD_TYPE         ?= ss
 
 .PHONY: build-docker-image build deb-build deb-clean deb-test update-changelog

--- a/debs/xenial/archivematica-storage-service/debian-storage-service/postinst
+++ b/debs/xenial/archivematica-storage-service/debian-storage-service/postinst
@@ -55,6 +55,7 @@ if [[ $2 == '1:0.7.'* ]]; then
 fi
 
 ${SS_ENV_DIR}/bin/python manage.py migrate
+mkdir -p /usr/lib/archivematica/storage-service/assets
 ${SS_ENV_DIR}/bin/python manage.py collectstatic --noinput --clear
 ${SS_ENV_DIR}/bin/python manage.py backfill_api_keys
 

--- a/debs/xenial/archivematica-storage-service/debian-storage-service/postinst
+++ b/debs/xenial/archivematica-storage-service/debian-storage-service/postinst
@@ -55,7 +55,7 @@ if [[ $2 == '1:0.7.'* ]]; then
 fi
 
 ${SS_ENV_DIR}/bin/python manage.py migrate
-${SS_ENV_DIR}/bin/python manage.py collectstatic --noinput
+${SS_ENV_DIR}/bin/python manage.py collectstatic --noinput --clear
 ${SS_ENV_DIR}/bin/python manage.py backfill_api_keys
 
 echo "updating directory permissions"

--- a/debs/xenial/archivematica/Makefile
+++ b/debs/xenial/archivematica/Makefile
@@ -7,8 +7,8 @@ GPG_ID ?= 0F4A4D31
 PACKBUILD_EXTRA_ARGS ?= 
 #PACKBUILD_EXTRA_ARGS ?= "-b 1"
 BRANCH     ?= qa/1.x
-VERSION     ?= 1.8.0
-RELEASE       ?= -2
+VERSION     ?= 1.8.1
+RELEASE       ?= -1
 BUILD_TYPE         ?= am
 
 .PHONY: build-docker-image build deb-build deb-clean deb-test update-changelog

--- a/debs/xenial/archivematica/Makefile
+++ b/debs/xenial/archivematica/Makefile
@@ -6,9 +6,9 @@ DOCKER_IMAGE  = "debbuild-$(NAME)-$(VERSION)"
 GPG_ID ?= 0F4A4D31
 PACKBUILD_EXTRA_ARGS ?= 
 #PACKBUILD_EXTRA_ARGS ?= "-b 1"
-BRANCH     ?= stable/1.7.x
-VERSION     ?= 1.7.0
-RELEASE       ?= +rc1~xenial
+BRANCH     ?= qa/1.x
+VERSION     ?= 1.8.0
+RELEASE       ?= -2
 BUILD_TYPE         ?= am
 
 .PHONY: build-docker-image build deb-build deb-clean deb-test update-changelog

--- a/debs/xenial/archivematica/debian-MCPClient/changelog
+++ b/debs/xenial/archivematica/debian-MCPClient/changelog
@@ -1,3 +1,10 @@
+archivematica-mcp-client (1:1.8.1-1~16.04) xenial; urgency=high
+
+  * commit: e240825332b76f3cc50b66646921fd9b1ab84d4b
+  * checkout: v1.8.1
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Wed, 09 Jan 2019 18:05:06 +0000
+
 archivematica-mcp-client (1:1.8.0-1~16.04) xenial; urgency=high
 
   * commit: 707e9332f0bebf4c32def012e30752314a207d48

--- a/debs/xenial/archivematica/debian-MCPServer/changelog
+++ b/debs/xenial/archivematica/debian-MCPServer/changelog
@@ -1,3 +1,10 @@
+archivematica-mcp-server (1:1.8.1-1~16.04) xenial; urgency=high
+
+  * commit: e240825332b76f3cc50b66646921fd9b1ab84d4b
+  * checkout: v1.8.1
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Wed, 09 Jan 2019 18:10:54 +0000
+
 archivematica-mcp-server (1:1.8.0-1~16.04) xenial; urgency=high
 
   * commit: 707e9332f0bebf4c32def012e30752314a207d48

--- a/debs/xenial/archivematica/debian-archivematicaCommon/changelog
+++ b/debs/xenial/archivematica/debian-archivematicaCommon/changelog
@@ -1,3 +1,10 @@
+archivematica-common (1:1.8.1-1~16.04) xenial; urgency=high
+
+  * commit: e240825332b76f3cc50b66646921fd9b1ab84d4b
+  * checkout: v1.8.1
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Wed, 09 Jan 2019 18:15:37 +0000
+
 archivematica-common (1:1.8.0-1~16.04) xenial; urgency=high
 
   * commit: 707e9332f0bebf4c32def012e30752314a207d48

--- a/debs/xenial/archivematica/debian-dashboard/changelog
+++ b/debs/xenial/archivematica/debian-dashboard/changelog
@@ -1,3 +1,10 @@
+archivematica-dashboard (1:1.8.1-1~16.04) xenial; urgency=high
+
+  * commit: e240825332b76f3cc50b66646921fd9b1ab84d4b
+  * checkout: v1.8.1
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Wed, 09 Jan 2019 17:48:48 +0000
+
 archivematica-dashboard (1:1.8.0-1~16.04) xenial; urgency=high
 
   * commit: 707e9332f0bebf4c32def012e30752314a207d48

--- a/debs/xenial/archivematica/debian-dashboard/postinst
+++ b/debs/xenial/archivematica/debian-dashboard/postinst
@@ -48,7 +48,7 @@ fi
 /usr/share/archivematica/dashboard/manage.py migrate --settings='settings.production'
 
 # Collect static content
-/usr/share/archivematica/dashboard/manage.py collectstatic --noinput
+/usr/share/archivematica/dashboard/manage.py collectstatic --noinput --clear
 
 
 #DEBHELPER#

--- a/debs/xenial/archivematica/debian-dashboard/postinst
+++ b/debs/xenial/archivematica/debian-dashboard/postinst
@@ -48,6 +48,7 @@ fi
 /usr/share/archivematica/dashboard/manage.py migrate --settings='settings.production'
 
 # Collect static content
+mkdir -p /usr/share/archivematica/dashboard/static
 /usr/share/archivematica/dashboard/manage.py collectstatic --noinput --clear
 
 

--- a/rpm/archivematica-storage-service/Makefile
+++ b/rpm/archivematica-storage-service/Makefile
@@ -1,7 +1,7 @@
 NAME          = archivematica-storage-service
-BRANCH        ?= stable/0.11.x
-VERSION       ?= 0.11.0
-RELEASE       ?= rc1
+BRANCH        ?= qa/1.x
+VERSION       ?= 0.13.0
+RELEASE       ?= 2
 RPM_TOPDIR    = "/rpmbuild"
 DOCKER_VOLUME = "/src"
 DOCKER_IMAGE  = $(subst ~,-,"rpmbuild-$(NAME)-$(VERSION)")

--- a/rpm/archivematica-storage-service/Makefile
+++ b/rpm/archivematica-storage-service/Makefile
@@ -1,7 +1,7 @@
 NAME          = archivematica-storage-service
 BRANCH        ?= qa/1.x
 VERSION       ?= 0.13.0
-RELEASE       ?= 2
+RELEASE       ?= 3
 RPM_TOPDIR    = "/rpmbuild"
 DOCKER_VOLUME = "/src"
 DOCKER_IMAGE  = $(subst ~,-,"rpmbuild-$(NAME)-$(VERSION)")

--- a/rpm/archivematica-storage-service/package.spec
+++ b/rpm/archivematica-storage-service/package.spec
@@ -102,7 +102,7 @@ sed -i "s/<replace-with-key>/\"$KEYCMD\"/g" /etc/sysconfig/archivematica-storage
 # Run django collectstatic task
 cd /usr/lib/archivematica/storage-service
 export $(cat /etc/sysconfig/archivematica-storage-service)
-/usr/share/archivematica/virtualenvs/archivematica-storage-service/bin/python manage.py collectstatic --noinput
+/usr/share/archivematica/virtualenvs/archivematica-storage-service/bin/python manage.py collectstatic --noinput --clear
 
 systemctl daemon-reload
 
@@ -113,4 +113,8 @@ fi
 if [ x$(semanage port -l | grep http_port_t | grep 8001 | wc -l) == x0 ]; then
   semanage port -a -t http_port_t -p tcp 8001
 fi
+
+%changelog
+* Tue Dec 11 2018 - sysadmin@artefactual.com
+- Update collectstatic command: added --clear option
 

--- a/rpm/archivematica-storage-service/package.spec
+++ b/rpm/archivematica-storage-service/package.spec
@@ -102,6 +102,7 @@ sed -i "s/<replace-with-key>/\"$KEYCMD\"/g" /etc/sysconfig/archivematica-storage
 # Run django collectstatic task
 cd /usr/lib/archivematica/storage-service
 export $(cat /etc/sysconfig/archivematica-storage-service)
+mkdir -p /usr/lib/archivematica/storage-service/assets
 /usr/share/archivematica/virtualenvs/archivematica-storage-service/bin/python manage.py collectstatic --noinput --clear
 
 systemctl daemon-reload
@@ -115,6 +116,7 @@ if [ x$(semanage port -l | grep http_port_t | grep 8001 | wc -l) == x0 ]; then
 fi
 
 %changelog
+* Wed Jan 09 2019 - sysadmin@artefactual.com
+- Create collectstatic directory in post script
 * Tue Dec 11 2018 - sysadmin@artefactual.com
 - Update collectstatic command: added --clear option
-

--- a/rpm/archivematica/Makefile
+++ b/rpm/archivematica/Makefile
@@ -4,8 +4,8 @@ DOCKER_VOLUME = "/src"
 DOCKER_IMAGE  ?= $(subst ~,-,"rpmbuild-$(NAME)-$(VERSION)")
 
 BRANCH     ?= qa/1.x
-VERSION     ?= 1.8.0
-RELEASE       ?= 2
+VERSION     ?= 1.8.1
+RELEASE       ?= 1
 
 RPMBUILD_ARGS := \
 	--define "_topdir $(RPM_TOPDIR)" \

--- a/rpm/archivematica/Makefile
+++ b/rpm/archivematica/Makefile
@@ -3,9 +3,9 @@ RPM_TOPDIR    = "/rpmbuild"
 DOCKER_VOLUME = "/src"
 DOCKER_IMAGE  ?= $(subst ~,-,"rpmbuild-$(NAME)-$(VERSION)")
 
-BRANCH     ?= stable/1.7.x
-VERSION     ?= 1.7.0
-RELEASE       ?= rc1
+BRANCH     ?= qa/1.x
+VERSION     ?= 1.8.0
+RELEASE       ?= 2
 
 RPMBUILD_ARGS := \
 	--define "_topdir $(RPM_TOPDIR)" \

--- a/rpm/archivematica/archivematica.spec
+++ b/rpm/archivematica/archivematica.spec
@@ -270,7 +270,7 @@ sed -i "s/CHANGE_ME_WITH_A_SECRET_KEY/\"$KEY\"/g" /etc/sysconfig/archivematica-d
 # Run django collectstatic
 export $(cat /etc/sysconfig/archivematica-dashboard)
 cd /usr/share/archivematica/dashboard
-/usr/share/archivematica/virtualenvs/archivematica-dashboard/bin/python manage.py collectstatic --noinput
+/usr/share/archivematica/virtualenvs/archivematica-dashboard/bin/python manage.py collectstatic --noinput --clear
 
 chown -R archivematica:archivematica /var/log/archivematica/dashboard
 systemctl daemon-reload
@@ -279,4 +279,7 @@ if [ x$(semanage port -l | grep http_port_t | grep 7400 | wc -l) == x0 ]; then
   semanage port -a -t http_port_t -p tcp 7400
 fi
 
+%changelog
+* Tue Dec 11 2018 - sysadmin@artefactual.com
+- Update collectstatic command: added --clear option
 

--- a/rpm/archivematica/archivematica.spec
+++ b/rpm/archivematica/archivematica.spec
@@ -268,6 +268,7 @@ KEY=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
 sed -i "s/CHANGE_ME_WITH_A_SECRET_KEY/\"$KEY\"/g" /etc/sysconfig/archivematica-dashboard
 
 # Run django collectstatic
+mkdir -p /usr/share/archivematica/dashboard/static
 export $(cat /etc/sysconfig/archivematica-dashboard)
 cd /usr/share/archivematica/dashboard
 /usr/share/archivematica/virtualenvs/archivematica-dashboard/bin/python manage.py collectstatic --noinput --clear
@@ -280,6 +281,8 @@ if [ x$(semanage port -l | grep http_port_t | grep 7400 | wc -l) == x0 ]; then
 fi
 
 %changelog
+* Wed Jan 09 2019 - sysadmin@artefactual.com
+- Create collectstatic directory in post script
 * Tue Dec 11 2018 - sysadmin@artefactual.com
 - Update collectstatic command: added --clear option
 


### PR DESCRIPTION
This PR cherry picks these commits used to build the AM1.8.1 packages from qa/1.x branch:

2900dcdec1baa3c67d28f447d8701f29de1431ef
3d37c81779a88846705b546fb9fbccc8de51b310
1eb9999ed20be3f296f5d4f7ed9a0fd97c5cb176
ac320d5d4a14d59fdb27a4ecae695913532b2538

Connects to [archivematica/Issues#360](https://github.com/archivematica/Issues/issues/360)
Connects to archivematica/Issues#397
Connects to archivematica/Issues#413
Connects to archivematica/Issues#476