### PR TITLE
deb: Set utf8 encoding for MCP database

### DIFF
--- a/debs/bionic/archivematica/debian-MCPServer/control
+++ b/debs/bionic/archivematica/debian-MCPServer/control
@@ -14,6 +14,7 @@ Depends:
 	archivematica-common(>=1.6.0),
 	libmysqlclient20|libmysqlclient18,
 	dbconfig-common,
+	dbconfig-mysql,
 	mysql-server,
 	gearman
 Description: MCP Server for Archivematica

--- a/debs/bionic/archivematica/debian-MCPServer/postinst
+++ b/debs/bionic/archivematica/debian-MCPServer/postinst
@@ -1,7 +1,10 @@
 #!/bin/sh
 # source debconf stuff
 . /usr/share/debconf/confmodule
-. /usr/share/dbconfig-common/dpkg/postinst
+. /usr/share/dbconfig-common/dpkg/postinst.mysql
+
+# Set the default database encoding to UTF8
+dbc_mysql_createdb_encoding="UTF8"
 
 dbc_go archivematica-mcp-server $@
 

--- a/debs/bionic/archivematica/debian-MCPServer/postrm
+++ b/debs/bionic/archivematica/debian-MCPServer/postrm
@@ -1,5 +1,22 @@
 #!/bin/sh
 
+if [ -f /usr/share/debconf/confmodule ]; then
+    . /usr/share/debconf/confmodule
+fi
+
+if [ -f /usr/share/dbconfig-common/dpkg/postrm.mysql ]; then
+    . /usr/share/dbconfig-common/dpkg/postrm.mysql
+    dbc_go archivematica-mcp-server $@
+fi
+
+if [ "$1" = "purge" ]; then
+	rm -f /etc/dbconfig-common/archivematica-mcp-server.conf
+	if which ucf >/dev/null 2>&1; then
+		ucf --purge /etc/dbconfig-common/archivematica-mcp-server.conf
+		ucfr --purge archivematica-mcp-server /etc/dbconfig-common/archivematica-mcp-server.conf
+	fi
+fi
+
 if [ "$1" = "purge" ]; then
     rm -f /etc/default/archivematica-mcp-server
     if which ucf >/dev/null 2>&1; then

--- a/debs/bionic/archivematica/debian-MCPServer/prerm
+++ b/debs/bionic/archivematica/debian-MCPServer/prerm
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+. /usr/share/debconf/confmodule
+. /usr/share/dbconfig-common/dpkg/prerm.mysql 
+dbc_go archivematica-mcp-server $@
+
+#DEBHELPER#

--- a/debs/xenial/archivematica/debian-MCPServer/control
+++ b/debs/xenial/archivematica/debian-MCPServer/control
@@ -14,6 +14,7 @@ Depends:
 	archivematica-common(>=1.6.0),
 	libmysqlclient20|libmysqlclient18,
 	dbconfig-common,
+	dbconfig-mysql,
 	mysql-server,
 	gearman
 Description: MCP Server for Archivematica

--- a/debs/xenial/archivematica/debian-MCPServer/postinst
+++ b/debs/xenial/archivematica/debian-MCPServer/postinst
@@ -1,7 +1,10 @@
 #!/bin/sh
 # source debconf stuff
 . /usr/share/debconf/confmodule
-. /usr/share/dbconfig-common/dpkg/postinst
+. /usr/share/dbconfig-common/dpkg/postinst.mysql
+
+# Set the default database encoding to UTF8
+dbc_mysql_createdb_encoding="UTF8"
 
 dbc_go archivematica-mcp-server $@
 

--- a/debs/xenial/archivematica/debian-MCPServer/postrm
+++ b/debs/xenial/archivematica/debian-MCPServer/postrm
@@ -1,5 +1,22 @@
 #!/bin/sh
 
+if [ -f /usr/share/debconf/confmodule ]; then
+    . /usr/share/debconf/confmodule
+fi
+
+if [ -f /usr/share/dbconfig-common/dpkg/postrm.mysql ]; then
+    . /usr/share/dbconfig-common/dpkg/postrm.mysql
+    dbc_go archivematica-mcp-server $@
+fi
+
+if [ "$1" = "purge" ]; then
+	rm -f /etc/dbconfig-common/archivematica-mcp-server.conf
+	if which ucf >/dev/null 2>&1; then
+		ucf --purge /etc/dbconfig-common/archivematica-mcp-server.conf
+		ucfr --purge archivematica-mcp-server /etc/dbconfig-common/archivematica-mcp-server.conf
+	fi
+fi
+
 if [ "$1" = "purge" ]; then
     rm -f /etc/default/archivematica-mcp-server
     if which ucf >/dev/null 2>&1; then

--- a/debs/xenial/archivematica/debian-MCPServer/prerm
+++ b/debs/xenial/archivematica/debian-MCPServer/prerm
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+. /usr/share/debconf/confmodule
+. /usr/share/dbconfig-common/dpkg/prerm.mysql 
+dbc_go archivematica-mcp-server $@
+
+#DEBHELPER#


### PR DESCRIPTION
This PR adds the following features:

- Use dbc_mysql_createdb_encoding="UTF8" to create database with UTF8
enconding.
- Remove /etc/dbconfig-common/archivematica-mcp-server.conf file when
purging archivematica-mcp-server package.
- Prompt when removing archivematica-mcp-server package, asking for MCP
database deletion.
- Add dbconfig-mysql dependency to archivematica-mcp-server package.

Connects to https://github.com/archivematica/Issues/issues/505