### PR TITLE
centos jhove: bump version to 1.6.7

### DIFF
--- a/rpm/jhove/Makefile
+++ b/rpm/jhove/Makefile
@@ -1,5 +1,5 @@
 NAME          = jhove
-VERSION       = d1.12.32
+VERSION       = 1.16.7
 RPM_TOPDIR    = "/rpmbuild"
 DOCKER_VOLUME = "/src"
 DOCKER_IMAGE  = "rpmbuild-$(NAME)-$(VERSION)"
@@ -27,7 +27,7 @@ rpm-build: rpm-clean
 	mkdir -p $(RPM_TOPDIR)
 	cp $(DOCKER_VOLUME)/package.spec $(RPM_TOPDIR)/package.spec
 	mkdir -p $(RPM_TOPDIR)/SOURCES/
-	wget -O $(RPM_TOPDIR)/SOURCES/$(VERSION).zip https://github.com/openpreserve/jhove/archive/$(VERSION).zip
+	wget -O $(RPM_TOPDIR)/SOURCES/$(VERSION).zip https://github.com/openpreserve/jhove/archive/v$(VERSION).zip
 	cp files/* $(RPM_TOPDIR)/SOURCES/
 	rpmbuild $(RPMBUILD_ARGS) -ba --clean $(RPM_TOPDIR)/package.spec
 

--- a/rpm/jhove/files/paths.patch
+++ b/rpm/jhove/files/paths.patch
@@ -7,8 +7,8 @@ diff -u jhove-installer/src/main/scripts.orig/jhove jhove-installer/src/main/scr
  
 -JHOVE_HOME=%INSTALL_PATH
 -JHOVE_VERSION=%APP_VER
-+JHOVE_HOME=/usr/share/jhove/
-+JHOVE_VERSION=1.12.0-SNAPSHOT
++JHOVE_HOME=/usr/share/jhove
++JHOVE_VERSION=1.16.0
  
  #XTRA_JARS=/users/stephen/xercesImpl.jar
  EXTRA_JARS=              # Extra .jar files to add to CLASSPATH
@@ -28,8 +28,8 @@ diff -u jhove-installer/src/main/scripts.orig/jhove-gui jhove-installer/src/main
  
 -JHOVE_HOME=%INSTALL_PATH
 -JHOVE_VERSION=%APP_VER
-+JHOVE_HOME=/usr/share/jhove/
-+JHOVE_VERSION=1.12.0-SNAPSHOT
++JHOVE_HOME=/usr/share/jhove
++JHOVE_VERSION=1.16.0
  
  #XTRA_JARS=/users/stephen/xercesImpl.jar
  EXTRA_JARS=              # Extra .jar files to add to CLASSPATH

--- a/rpm/jhove/package.spec
+++ b/rpm/jhove/package.spec
@@ -42,3 +42,7 @@ cp -rf jhove-installer/target/staging/bin %{buildroot}/usr/share/jhove/
 cp -rf lib %{buildroot}/usr/share/jhove/
 
 cp LICENSE README.md COPYING %{buildroot}/usr/share/doc/jhove/
+
+%changelog
+* Mon Feb 25 2019 - sysadmin@artefactual.com
+- Bump version to 1.16.7


### PR DESCRIPTION
This PR updates the jhove version to the same used by ubuntu packages.

Connected to https://github.com/archivematica/Issues/issues/521