### PR TITLE
deb bulk_extractor: Update package build method

### DIFF
--- a/debs/bionic/bulk_extractor/Dockerfile
+++ b/debs/bionic/bulk_extractor/Dockerfile
@@ -4,11 +4,10 @@ ARG GIT_URL
 ARG GIT_BRANCH
 ARG PACKAGE
 
+RUN apt-get update
 
-RUN apt-get update && \
-    apt-get install -y dpkg-dev git build-essential wget debhelper \
+RUN apt-get install -y dpkg-dev git build-essential wget debhelper \
     devscripts equivs
-
 
 RUN mkdir -p /debbuild/ && cd /debbuild && \
 	git clone $GIT_URL && \

--- a/debs/bionic/bulk_extractor/Makefile
+++ b/debs/bionic/bulk_extractor/Makefile
@@ -1,6 +1,6 @@
 NAME          = bulk_extractor
 VERSION       ?= 1.5.3
-RELEASE	      ?= 1~18.04
+RELEASE	      ?= 2~18.04
 GIT_URL	      = https://github.com/simsong/bulk_extractor
 DEB_TOPDIR    = "/debbuild"
 DOCKER_VOLUME = "/src"
@@ -28,6 +28,8 @@ deb-build: deb-clean
 	@echo "==> Update changelog."
 	cd /debbuild/$(NAME) && dch -v $(VERSION)-$(RELEASE) -D xenial "New upstream release"
 
+	@echo "==> Run bootstrap.sh."
+	cd /debbuild/$(NAME) && sh bootstrap.sh
 	@echo "==> Build package."
 	cd /debbuild/$(NAME) && dpkg-buildpackage 
 	@echo "==> Copying built  files."

--- a/debs/bionic/bulk_extractor/debian/control
+++ b/debs/bionic/bulk_extractor/debian/control
@@ -5,11 +5,17 @@ Maintainer: Artefactual Systems Inc. <sysadmin@artefactual.com>
 Standards-Version: 3.9.3
 Build-Depends: 
     debhelper (>= 9),
+    dh-autoreconf,
     build-essential,
     flex,
     libcrypto++-dev,
     bison,
-    libssl-dev
+    libssl1.0-dev,
+    expat,
+    libewf-dev,
+    libafflib-dev,
+    libboost-all-dev,
+    openjdk-8-jdk
 
 Package: bulk-extractor
 Architecture: any

--- a/debs/bionic/bulk_extractor/debian/rules
+++ b/debs/bionic/bulk_extractor/debian/rules
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 %:
-	dh $@
+	dh $@ -with autoreconf
 
 # make check is broken in the 1.5.5 release; re-enable in next release
 # https://github.com/simsong/bulk_extractor/commit/1518072d5dbbf9fbb6f3841833241fdeaa2507b6

--- a/debs/xenial/bulk_extractor/Dockerfile
+++ b/debs/xenial/bulk_extractor/Dockerfile
@@ -5,8 +5,9 @@ ARG GIT_BRANCH
 ARG PACKAGE
 
 
-RUN apt-get update && \
-    apt-get install -y dpkg-dev git build-essential wget debhelper \
+RUN apt-get update
+
+RUN apt-get install -y dpkg-dev git build-essential wget debhelper \
     devscripts equivs
 
 

--- a/debs/xenial/bulk_extractor/Makefile
+++ b/debs/xenial/bulk_extractor/Makefile
@@ -1,6 +1,6 @@
 NAME          = bulk_extractor
 VERSION       ?= 1.5.3
-RELEASE	      ?= 1~16.04
+RELEASE	      ?= 2~16.04
 GIT_URL	      = https://github.com/simsong/bulk_extractor
 DEB_TOPDIR    = "/debbuild"
 DOCKER_VOLUME = "/src"
@@ -28,6 +28,8 @@ deb-build: deb-clean
 	@echo "==> Update changelog."
 	cd /debbuild/$(NAME) && dch -v $(VERSION)-$(RELEASE) -D xenial "New upstream release"
 
+	@echo "==> Run bootstrap.sh."
+	cd /debbuild/$(NAME) && sh bootstrap.sh
 	@echo "==> Build package."
 	cd /debbuild/$(NAME) && dpkg-buildpackage 
 	@echo "==> Copying built  files."

--- a/debs/xenial/bulk_extractor/debian/control
+++ b/debs/xenial/bulk_extractor/debian/control
@@ -5,11 +5,17 @@ Maintainer: Artefactual Systems Inc. <sysadmin@artefactual.com>
 Standards-Version: 3.9.3
 Build-Depends: 
     debhelper (>= 9),
+    dh-autoreconf,
     build-essential,
     flex,
     libcrypto++-dev,
     bison,
-    libssl-dev
+    libssl-dev,
+    expat,
+    libewf-dev,
+    libafflib-dev,
+    libboost-all-dev,
+    openjdk-8-jdk
 
 Package: bulk-extractor
 Architecture: any

--- a/debs/xenial/bulk_extractor/debian/rules
+++ b/debs/xenial/bulk_extractor/debian/rules
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 %:
-	dh $@
+	dh $@ -with autoreconf
 
 # make check is broken in the 1.5.5 release; re-enable in next release
 # https://github.com/simsong/bulk_extractor/commit/1518072d5dbbf9fbb6f3841833241fdeaa2507b6


### PR DESCRIPTION
This PR adds the following features:

* Dockerfile: Separate "apt-get update" and "apt-get upgrade" to use
cache. Needed when installing dependencies in bionic.

* make: Use autoreconf to build package.

* dependencies: Increase dependendencies (java, libboost, libewf,
libafflib).

* make: run "sh bootstrap.sh" before running automake.

* bionic: use libssl1.0-dev instead of libssl-dev to build package.

Connects to https://github.com/archivematica/Issues/issues/527