### PR TITLE
deb bulk-extractor: Bump version to 1.5.5

### DIFF
--- a/debs/bionic/bulk_extractor/Dockerfile
+++ b/debs/bionic/bulk_extractor/Dockerfile
@@ -1,8 +1,9 @@
 FROM ubuntu:bionic
 
-ARG GIT_URL
-ARG GIT_BRANCH
+ARG SRC_URL
 ARG PACKAGE
+ARG SRC_VERSION
+ARG SRC_SHA256
 
 RUN apt-get update
 
@@ -10,9 +11,11 @@ RUN apt-get install -y dpkg-dev git build-essential wget debhelper \
     devscripts equivs
 
 RUN mkdir -p /debbuild/ && cd /debbuild && \
-	git clone $GIT_URL && \
-	cd $PACKAGE && \
-	git checkout $GIT_BRANCH
+	wget $SRC_URL && \
+	echo "$SRC_SHA256  $PACKAGE-$SRC_VERSION.tar.gz" | sha256sum --check && \
+	tar xfz $PACKAGE-$SRC_VERSION.tar.gz && \
+        mv $PACKAGE-$SRC_VERSION $PACKAGE && \
+	cd $PACKAGE
 
 ADD debian /debbuild/$PACKAGE/debian
 

--- a/debs/bionic/bulk_extractor/Makefile
+++ b/debs/bionic/bulk_extractor/Makefile
@@ -1,7 +1,8 @@
 NAME          = bulk_extractor
-VERSION       ?= 1.5.3
-RELEASE	      ?= 2~18.04
-GIT_URL	      = https://github.com/simsong/bulk_extractor
+VERSION       ?= 1.5.5
+RELEASE	      ?= 1~18.04
+SRC_URL       = http://downloads.digitalcorpora.org/downloads/bulk_extractor/bulk_extractor-1.5.5.tar.gz
+SRC_SHA256    = 297a57808c12b81b8e0d82222cf57245ad988804ab467eb0a70cf8669594e8ed
 DEB_TOPDIR    = "/debbuild"
 DOCKER_VOLUME = "/src"
 DOCKER_IMAGE  = "debbuild-$(NAME)-$(VERSION)"
@@ -12,11 +13,11 @@ all: build-docker-image build
 
 build-docker-image:
 	@echo "==> Building Docker image with build environment."
-	@docker build --tag "$(DOCKER_IMAGE)" --build-arg GIT_URL="$(GIT_URL)" --build-arg GIT_BRANCH=v"$(VERSION)" --build-arg PACKAGE="$(NAME)" .
+	@docker build --tag "$(DOCKER_IMAGE)" --build-arg SRC_URL="$(SRC_URL)" --build-arg SRC_VERSION="$(VERSION)" --build-arg SRC_SHA256="$(SRC_SHA256)" --build-arg PACKAGE="$(NAME)" .
 
 update-changelog:
 	@echo "==> Update changelog."
-	@dch -v $(VERSION)-$(RELEASE) -D xenial "New upstream release"
+	@dch -v $(VERSION)-$(RELEASE) -D bionic "New upstream release"
 
 build:
 	@echo "==> Building deb."
@@ -26,7 +27,7 @@ deb-build: deb-clean
 	@echo "==> Install dependencies."
 	cd /debbuild/$(NAME) && yes | mk-build-deps --install debian/control
 	@echo "==> Update changelog."
-	cd /debbuild/$(NAME) && dch -v $(VERSION)-$(RELEASE) -D xenial "New upstream release"
+	cd /debbuild/$(NAME) && dch -v $(VERSION)-$(RELEASE) -D bionic "New upstream release"
 
 	@echo "==> Run bootstrap.sh."
 	cd /debbuild/$(NAME) && sh bootstrap.sh

--- a/debs/bionic/bulk_extractor/debian/changelog
+++ b/debs/bionic/bulk_extractor/debian/changelog
@@ -1,3 +1,20 @@
+bulk-extractor (1.5.5-1~18.04) bionic; urgency=low
+
+  * Bump version to 1.5.5
+  * Use http://downloads.digitalcorpora.org/downloads/bulk_extractor/ instead of github
+
+ -- Miguel Medinilla <sysadmin@artefactual.com>  Mon, 27 Feb 2019 12:03:02 -0700
+
+bulk-extractor (1.5.3-1~18.04) bionic; urgency=low
+
+  * Bump version to 1.5.3
+  * Use autoreconf to build package
+  * Run "sh bootstrap.sh" before running automake.
+  * Use libssl1.0-dev instead of libssl-dev to build package
+  * Increase dependendencies: java, libboost, libewf, libafflib
+
+ -- Miguel Medinilla <sysadmin@artefactual.com>  Mon, 26 Feb 2019 12:32:01 -0700
+
 bulk-extractor (1.5.0-1~16.04) xenial; urgency=low
 
   * New upstream release

--- a/debs/xenial/bulk_extractor/Dockerfile
+++ b/debs/xenial/bulk_extractor/Dockerfile
@@ -1,20 +1,21 @@
 FROM ubuntu:xenial
 
-ARG GIT_URL
-ARG GIT_BRANCH
+ARG SRC_URL
 ARG PACKAGE
-
+ARG SRC_VERSION
+ARG SRC_SHA256
 
 RUN apt-get update
 
 RUN apt-get install -y dpkg-dev git build-essential wget debhelper \
     devscripts equivs
 
-
 RUN mkdir -p /debbuild/ && cd /debbuild && \
-	git clone $GIT_URL && \
-	cd $PACKAGE && \
-	git checkout $GIT_BRANCH
+	wget $SRC_URL && \
+	echo "$SRC_SHA256  $PACKAGE-$SRC_VERSION.tar.gz" | sha256sum --check && \
+	tar xfz $PACKAGE-$SRC_VERSION.tar.gz && \
+        mv $PACKAGE-$SRC_VERSION $PACKAGE && \
+	cd $PACKAGE
 
 ADD debian /debbuild/$PACKAGE/debian
 

--- a/debs/xenial/bulk_extractor/Makefile
+++ b/debs/xenial/bulk_extractor/Makefile
@@ -1,7 +1,8 @@
 NAME          = bulk_extractor
-VERSION       ?= 1.5.3
-RELEASE	      ?= 2~16.04
-GIT_URL	      = https://github.com/simsong/bulk_extractor
+VERSION       ?= 1.5.5
+RELEASE	      ?= 1~16.04
+SRC_URL       = http://downloads.digitalcorpora.org/downloads/bulk_extractor/bulk_extractor-1.5.5.tar.gz
+SRC_SHA256    = 297a57808c12b81b8e0d82222cf57245ad988804ab467eb0a70cf8669594e8ed
 DEB_TOPDIR    = "/debbuild"
 DOCKER_VOLUME = "/src"
 DOCKER_IMAGE  = "debbuild-$(NAME)-$(VERSION)"
@@ -12,7 +13,7 @@ all: build-docker-image build
 
 build-docker-image:
 	@echo "==> Building Docker image with build environment."
-	@docker build --tag "$(DOCKER_IMAGE)" --build-arg GIT_URL="$(GIT_URL)" --build-arg GIT_BRANCH=v"$(VERSION)" --build-arg PACKAGE="$(NAME)" .
+	@docker build --tag "$(DOCKER_IMAGE)" --build-arg SRC_URL="$(SRC_URL)" --build-arg SRC_VERSION="$(VERSION)" --build-arg SRC_SHA256="$(SRC_SHA256)" --build-arg PACKAGE="$(NAME)" .
 
 update-changelog:
 	@echo "==> Update changelog."

--- a/debs/xenial/bulk_extractor/debian/changelog
+++ b/debs/xenial/bulk_extractor/debian/changelog
@@ -1,3 +1,19 @@
+bulk-extractor (1.5.5-1~16.04) xenial; urgency=low
+
+  * Bump version to 1.5.5
+  * Use http://downloads.digitalcorpora.org/downloads/bulk_extractor/ instead of github
+
+ -- Miguel Medinilla <sysadmin@artefactual.com>  Mon, 27 Feb 2019 12:03:02 -0700
+
+bulk-extractor (1.5.3-1~16.04) xenial; urgency=low
+
+  * Bump version to 1.5.3
+  * Use autoreconf to build package
+  * Run "sh bootstrap.sh" before running automake.
+  * Increase dependendencies: java, libboost, libewf, libafflib
+
+ -- Miguel Medinilla <sysadmin@artefactual.com>  Mon, 26 Feb 2019 12:32:01 -0700
+
 bulk-extractor (1.5.0-1~16.04) xenial; urgency=low
 
   * New upstream release


### PR DESCRIPTION
* Bump version to 1.5.5
* Use http://downloads.digitalcorpora.org/downloads/bulk_extractor/
instead of github. Github repository has no release 1.5.5, so it is
needed to download the source tarball from download site for latest
releases.
* Check tarball sha256sum.

Connects to https://github.com/archivematica/Issues/issues/527