### PR TITLE
systemd: Add 5 retries to systemd dashboard

### DIFF
--- a/debs/bionic/archivematica/debian-dashboard/archivematica-dashboard.service
+++ b/debs/bionic/archivematica/debian-dashboard/archivematica-dashboard.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Archivematica Dashboard
 After=syslog.target network.target
+StartLimitInterval=200
+StartLimitBurst=5
 
 [Service]
 PIDFile=/run/archivematica-dashboard_gunicorn.pid
@@ -11,7 +13,9 @@ WorkingDirectory=/usr/share/archivematica/dashboard/
 ExecStart=/usr/share/archivematica/virtualenvs/archivematica-dashboard/bin/gunicorn --config /etc/archivematica/dashboard.gunicorn-config.py wsgi:application
 ExecReload=/bin/kill -s HUP $MAINPID
 ExecStop=/bin/kill -s TERM $MAINPID
-PrivateTmp=true      
+PrivateTmp=true
+Restart=always
+RestartSec=30
 
 [Install]
 WantedBy=multi-user.target

--- a/debs/xenial/archivematica/debian-dashboard/archivematica-dashboard.service
+++ b/debs/xenial/archivematica/debian-dashboard/archivematica-dashboard.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Archivematica Dashboard
 After=syslog.target network.target
+StartLimitInterval=200
+StartLimitBurst=5
 
 [Service]
 PIDFile=/run/archivematica-dashboard_gunicorn.pid
@@ -11,7 +13,9 @@ WorkingDirectory=/usr/share/archivematica/dashboard/
 ExecStart=/usr/share/archivematica/virtualenvs/archivematica-dashboard/bin/gunicorn --config /etc/archivematica/dashboard.gunicorn-config.py wsgi:application
 ExecReload=/bin/kill -s HUP $MAINPID
 ExecStop=/bin/kill -s TERM $MAINPID
-PrivateTmp=true      
+PrivateTmp=true
+Restart=always
+RestartSec=30
 
 [Install]
 WantedBy=multi-user.target

--- a/rpm/archivematica/etc/archivematica-dashboard.service
+++ b/rpm/archivematica/etc/archivematica-dashboard.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Archivematica Dashboard
 After=syslog.target network.target
+StartLimitInterval=200
+StartLimitBurst=5
 
 [Service]
 PIDFile=/run/archivematica-dashboard_gunicorn.pid
@@ -11,7 +13,9 @@ WorkingDirectory=/usr/share/archivematica/dashboard/
 ExecStart=/usr/share/archivematica/virtualenvs/archivematica-dashboard/bin/gunicorn --config /etc/archivematica/dashboard.gunicorn-config.py wsgi:application
 ExecReload=/bin/kill -s HUP $MAINPID
 ExecStop=/bin/kill -s TERM $MAINPID
-PrivateTmp=true      
+PrivateTmp=true
+Restart=always
+RestartSec=30
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The elasticsearch service can take several seconds for listening in 9200
port after systemd says it is up and running. Adding the retries to the
dashboard systemd file will fix the issue.

Connects to archivematica/Issues#600
