### PR TITLE
deb: Remove dh-virtualenv build path in venvs

### DIFF
--- a/debs/bionic/archivematica-storage-service/debian-storage-service/postinst
+++ b/debs/bionic/archivematica-storage-service/debian-storage-service/postinst
@@ -13,6 +13,16 @@ else
   adduser --uid 333 --group --system --home /var/lib/archivematica/ archivematica
 fi
 
+# Remove dh-virtualenv build path in editable pip requirements and other local/bin files
+# https://github.com/spotify/dh-virtualenv/issues/134
+# https://github.com/archivematica/Issues/issues/903
+for filename in /usr/share/archivematica/virtualenvs/archivematica-storage-service/local/bin/* \
+    /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python2.7/site-packages/*.pth \
+    /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python2.7/site-packages/*.egg-link ; do
+    if [ -f "$filename" ]; then
+        sed -i "s/\/src\/src\/archivematica-storage-service\/debian\/archivematica-storage-service//g" $filename
+    fi
+done
 
 echo "creating django secret key"
 KEYCMD=$(python /var/archivematica/storage-service/make_key.py 2>&1)

--- a/debs/bionic/archivematica/debian-MCPClient/postinst
+++ b/debs/bionic/archivematica/debian-MCPClient/postinst
@@ -5,6 +5,17 @@ mkdir -p $logdir
 chown -R archivematica:archivematica $logdir
 chmod -R g+s $logdir
 
+# Remove dh-virtualenv build path in editable pip requirements and other local/bin files
+# https://github.com/spotify/dh-virtualenv/issues/134
+# https://github.com/archivematica/Issues/issues/903
+for filename in /usr/share/archivematica/virtualenvs/archivematica-mcp-client/local/bin/* \
+    /usr/share/archivematica/virtualenvs/archivematica-mcp-client/lib/python2.7/site-packages/*.pth \
+    /usr/share/archivematica/virtualenvs/archivematica-mcp-client/lib/python2.7/site-packages/*.egg-link ; do
+    if [ -f "$filename" ]; then
+        sed -i "s/\/src\/src\/archivematica\/src\/MCPClient\/debian\/archivematica-mcp-client//g" $filename
+    fi
+done
+
 # Populate default mysql config
 DBPASS=$(grep "dbc_dbpass=" /etc/dbconfig-common/archivematica-mcp-server.conf| cut -d\= -f2- | tr -d \')
 sed -i "s/^\(ARCHIVEMATICA_MCPCLIENT_CLIENT_PASSWORD=\).*/\1$DBPASS/g" /etc/default/archivematica-mcp-client

--- a/debs/bionic/archivematica/debian-MCPServer/postinst
+++ b/debs/bionic/archivematica/debian-MCPServer/postinst
@@ -18,6 +18,17 @@ mkdir -p $logdir
 chown -R archivematica:archivematica $logdir
 chmod -R g+s $logdir
 
+# Remove dh-virtualenv build path in editable pip requirements and other local/bin files
+# https://github.com/spotify/dh-virtualenv/issues/134
+# https://github.com/archivematica/Issues/issues/903
+for filename in /usr/share/archivematica/virtualenvs/archivematica-mcp-server/local/bin/* \
+    /usr/share/archivematica/virtualenvs/archivematica-mcp-server/lib/python2.7/site-packages/*.pth \
+    /usr/share/archivematica/virtualenvs/archivematica-mcp-server/lib/python2.7/site-packages/*.egg-link ; do
+    if [ -f "$filename" ]; then
+        sed -i "s/\/src\/src\/archivematica\/src\/MCPServer\/debian\/archivematica-mcp-server//g" $filename
+    fi
+done
+
 # Populate default mysql config
 DBPASS=$(grep "dbc_dbpass=" /etc/dbconfig-common/archivematica-mcp-server.conf| cut -d\= -f2- | tr -d \')
 sed -i "s/^\(ARCHIVEMATICA_MCPSERVER_CLIENT_PASSWORD=\).*/\1$DBPASS/g" /etc/default/archivematica-mcp-server

--- a/debs/bionic/archivematica/debian-dashboard/postinst
+++ b/debs/bionic/archivematica/debian-dashboard/postinst
@@ -28,6 +28,17 @@ sed -i "s/^\(ARCHIVEMATICA_DASHBOARD_CLIENT_USER=\).*/\1$DBUSER/g" /etc/default/
 DBNAME=$(grep "dbc_dbname=" /etc/dbconfig-common/archivematica-mcp-server.conf| cut -d\= -f2- | tr -d \')
 sed -i "s/^\(ARCHIVEMATICA_DASHBOARD_CLIENT_DATABASE=\).*/\1$DBNAME/g" /etc/default/archivematica-dashboard
 
+# Remove dh-virtualenv build path in editable pip requirements and other local/bin files
+# https://github.com/spotify/dh-virtualenv/issues/134
+# https://github.com/archivematica/Issues/issues/903
+for filename in /usr/share/archivematica/virtualenvs/archivematica-dashboard/local/bin/* \
+    /usr/share/archivematica/virtualenvs/archivematica-dashboard/lib/python2.7/site-packages/*.pth \
+    /usr/share/archivematica/virtualenvs/archivematica-dashboard/lib/python2.7/site-packages/*.egg-link ; do
+    if [ -f "$filename" ]; then
+        sed -i "s/\/src\/src\/archivematica\/src\/dashboard\/debian\/archivematica-dashboard//g" $filename
+    fi
+done
+
 # Use ucf to preserve user changes in the default file
 ucfr archivematica-dashboard /etc/default/archivematica-dashboard
 ucf --debconf-ok /etc/default/archivematica-dashboard /etc/default/archivematica-dashboard


### PR DESCRIPTION
This PR removes dh-virtualenv build path in editable pip requirements and
other local/bin files. There's a bug in dh-virtualenv editable paths:

https://github.com/spotify/dh-virtualenv/issues/134

It happens when requirements.txt file has the "-e" option for git sources, but
it worked in AM version < 1.10 because the "-e" was not used.

Connects to https://github.com/archivematica/Issues/issues/903