### PR TITLE
xenial: Remove dh-virtualenv build path in venvs

### DIFF
--- a/debs/xenial/archivematica-storage-service/debian-storage-service/postinst
+++ b/debs/xenial/archivematica-storage-service/debian-storage-service/postinst
@@ -13,6 +13,16 @@ else
   adduser --uid 333 --group --system --home /var/lib/archivematica/ archivematica
 fi
 
+# Remove dh-virtualenv build path in editable pip requirements and other local/bin files
+# https://github.com/spotify/dh-virtualenv/issues/134
+# https://github.com/archivematica/Issues/issues/903
+for filename in /usr/share/archivematica/virtualenvs/archivematica-storage-service/local/bin/* \
+    /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python2.7/site-packages/*.pth \
+    /usr/share/archivematica/virtualenvs/archivematica-storage-service/lib/python2.7/site-packages/*.egg-link ; do
+    if [ -f "$filename" ]; then
+        sed -i "s/\/src\/src\/archivematica-storage-service\/debian\/archivematica-storage-service//g" $filename
+    fi
+done
 
 echo "creating django secret key"
 KEYCMD=$(python /var/archivematica/storage-service/make_key.py 2>&1)

--- a/debs/xenial/archivematica/debian-MCPClient/postinst
+++ b/debs/xenial/archivematica/debian-MCPClient/postinst
@@ -5,6 +5,17 @@ mkdir -p $logdir
 chown -R archivematica:archivematica $logdir
 chmod -R g+s $logdir
 
+# Remove dh-virtualenv build path in editable pip requirements and other local/bin files
+# https://github.com/spotify/dh-virtualenv/issues/134
+# https://github.com/archivematica/Issues/issues/903
+for filename in /usr/share/archivematica/virtualenvs/archivematica-mcp-client/local/bin/* \
+    /usr/share/archivematica/virtualenvs/archivematica-mcp-client/lib/python2.7/site-packages/*.pth \
+    /usr/share/archivematica/virtualenvs/archivematica-mcp-client/lib/python2.7/site-packages/*.egg-link ; do
+    if [ -f "$filename" ]; then
+        sed -i "s/\/src\/src\/archivematica\/src\/MCPClient\/debian\/archivematica-mcp-client//g" $filename
+    fi
+done
+
 # Populate default mysql config
 DBPASS=$(grep "dbc_dbpass=" /etc/dbconfig-common/archivematica-mcp-server.conf| cut -d\= -f2- | tr -d \')
 sed -i "s/^\(ARCHIVEMATICA_MCPCLIENT_CLIENT_PASSWORD=\).*/\1$DBPASS/g" /etc/default/archivematica-mcp-client

--- a/debs/xenial/archivematica/debian-MCPServer/postinst
+++ b/debs/xenial/archivematica/debian-MCPServer/postinst
@@ -18,6 +18,17 @@ mkdir -p $logdir
 chown -R archivematica:archivematica $logdir
 chmod -R g+s $logdir
 
+# Remove dh-virtualenv build path in editable pip requirements and other local/bin files
+# https://github.com/spotify/dh-virtualenv/issues/134
+# https://github.com/archivematica/Issues/issues/903
+for filename in /usr/share/archivematica/virtualenvs/archivematica-mcp-server/local/bin/* \
+    /usr/share/archivematica/virtualenvs/archivematica-mcp-server/lib/python2.7/site-packages/*.pth \
+    /usr/share/archivematica/virtualenvs/archivematica-mcp-server/lib/python2.7/site-packages/*.egg-link ; do
+    if [ -f "$filename" ]; then
+        sed -i "s/\/src\/src\/archivematica\/src\/MCPServer\/debian\/archivematica-mcp-server//g" $filename
+    fi
+done
+
 # Populate default mysql config
 DBPASS=$(grep "dbc_dbpass=" /etc/dbconfig-common/archivematica-mcp-server.conf| cut -d\= -f2- | tr -d \')
 sed -i "s/^\(ARCHIVEMATICA_MCPSERVER_CLIENT_PASSWORD=\).*/\1$DBPASS/g" /etc/default/archivematica-mcp-server

--- a/debs/xenial/archivematica/debian-dashboard/postinst
+++ b/debs/xenial/archivematica/debian-dashboard/postinst
@@ -18,6 +18,17 @@ pip install --upgrade -r /usr/share/archivematica/dashboard/requirements.txt
 KEY=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
 sed -i "s/CHANGE_ME_WITH_A_SECRET_KEY/\"$KEY\"/g" /etc/default/archivematica-dashboard
 
+# Remove dh-virtualenv build path in editable pip requirements and other local/bin files
+# https://github.com/spotify/dh-virtualenv/issues/134
+# https://github.com/archivematica/Issues/issues/903
+for filename in /usr/share/archivematica/virtualenvs/archivematica-dashboard/local/bin/* \
+    /usr/share/archivematica/virtualenvs/archivematica-dashboard/lib/python2.7/site-packages/*.pth \
+    /usr/share/archivematica/virtualenvs/archivematica-dashboard/lib/python2.7/site-packages/*.egg-link ; do
+    if [ -f "$filename" ]; then
+        sed -i "s/\/src\/src\/archivematica\/src\/dashboard\/debian\/archivematica-dashboard//g" $filename
+    fi
+done
+
 # Populate default mysql config
 DBPASS=$(grep "dbc_dbpass=" /etc/dbconfig-common/archivematica-mcp-server.conf| cut -d\= -f2- | tr -d \')
 sed -i "s/^\(ARCHIVEMATICA_DASHBOARD_CLIENT_PASSWORD=\).*/\1$DBPASS/g" /etc/default/archivematica-dashboard


### PR DESCRIPTION
This PR removes dh-virtualenv build path in editable pip requirements and
other local/bin files. There's a bug in dh-virtualenv editable paths:

spotify/dh-virtualenv#134

It happens when requirements.txt file has the "-e" option for git sources, but
it worked in AM version < 1.10 because the "-e" was not used.

Connects to archivematica/Issues#903