### PR TITLE
debs: Improve "export variables" in AM postinst scripts

### DIFF
--- a/debs/bionic/archivematica-storage-service/debian-storage-service/postinst
+++ b/debs/bionic/archivematica-storage-service/debian-storage-service/postinst
@@ -35,7 +35,9 @@ sed -i "s/<replace-with-key>/$KEYCMD/g" /etc/archivematica/storage-service.gunic
 ucfr archivematica-storage-service /etc/default/archivematica-storage-service
 ucf --debconf-ok /etc/default/archivematica-storage-service /etc/default/archivematica-storage-service
 
-export $(cat /etc/default/archivematica-storage-service)
+set -a
+source /etc/default/archivematica-storage-service
+set +a
 echo "creating symlink in /usr/lib/archivematica"
 rm -f /usr/lib/archivematica/storage-service
 ln -s -f ${SS_ENV_DIR}/lib/python2.7/site-packages/storage_service/ /usr/lib/archivematica/storage-service

--- a/debs/bionic/archivematica/debian-dashboard/postinst
+++ b/debs/bionic/archivematica/debian-dashboard/postinst
@@ -44,7 +44,9 @@ ucfr archivematica-dashboard /etc/default/archivematica-dashboard
 ucf --debconf-ok /etc/default/archivematica-dashboard /etc/default/archivematica-dashboard
 
 #this is required to allow syncdb to work properly
-export $(cat /etc/default/archivematica-dashboard)
+set -a
+source /etc/default/archivematica-dashboard
+set +a
 
 # Fake migrations if necessary.  $2 is old version
 if [[ $2 == '1:1.4.1'* ]]; then

--- a/debs/xenial/archivematica-storage-service/debian-storage-service/postinst
+++ b/debs/xenial/archivematica-storage-service/debian-storage-service/postinst
@@ -35,7 +35,9 @@ sed -i "s/<replace-with-key>/$KEYCMD/g" /etc/archivematica/storage-service.gunic
 ucfr archivematica-storage-service /etc/default/archivematica-storage-service
 ucf --debconf-ok /etc/default/archivematica-storage-service /etc/default/archivematica-storage-service
 
-export $(cat /etc/default/archivematica-storage-service)
+set -a
+source /etc/default/archivematica-storage-service
+set +a
 echo "creating symlink in /usr/lib/archivematica"
 rm -f /usr/lib/archivematica/storage-service
 ln -s -f ${SS_ENV_DIR}/lib/python2.7/site-packages/storage_service/ /usr/lib/archivematica/storage-service

--- a/debs/xenial/archivematica/debian-dashboard/postinst
+++ b/debs/xenial/archivematica/debian-dashboard/postinst
@@ -44,7 +44,9 @@ ucfr archivematica-dashboard /etc/default/archivematica-dashboard
 ucf --debconf-ok /etc/default/archivematica-dashboard /etc/default/archivematica-dashboard
 
 #this is required to allow syncdb to work properly
-export $(cat /etc/default/archivematica-dashboard)
+set -a
+source /etc/default/archivematica-dashboard
+set +a
 
 # Fake migrations if necessary.  $2 is old version
 if [[ $2 == '1:1.4.1'* ]]; then


### PR DESCRIPTION
The Ubuntu dashboard and storage-service postint scripts are using
the following command to export the /etc/default/archivematica-*
variables:

```
export $(cat /etc/default/archivematica-*)
```

It returns errors when there are commented out lines or exporting
locale variables, i.e.:

```
/var/lib/dpkg/info/archivematica-storage-service.postinst: line 38: export: `#': not a valid identifier
/var/lib/dpkg/info/archivematica-storage-service.postinst: line 38: warning: setlocale: LC_ALL: cannot change locale ("en_US.UTF-8")
```

This PR uses the same commands described in the documentation
to export the variables:

```
set -a
source /etc/default/archivematica-*
set +a
```

Connects to https://github.com/archivematica/Issues/issues/1004