### PR TITLE
siegfried: Update to 1.8.0 version

### DIFF
--- a/debs/siegfried/Dockerfile
+++ b/debs/siegfried/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:xenial
 
 # Environmnet variables needed during build
-ENV GOVERSION 1.11
+ENV GOVERSION 1.13
 ENV GOOS linux
 ENV GOARCH amd64
 

--- a/debs/siegfried/Makefile
+++ b/debs/siegfried/Makefile
@@ -1,8 +1,8 @@
 NAME          = siegfried
 PACKAGE       = siegfried
-VERSION       ?= 1.7.10
+VERSION       ?= 1.8.0
 RELEASE       ?= 1
-BRANCH        ?= v1.7.10
+BRANCH        ?= v1.8.0
 GIT_URL       = https://github.com/richardlehane/siegfried/
 DEB_TOPDIR    = "/debbuild"
 DOCKER_VOLUME = "/src"

--- a/debs/siegfried/debian/changelog
+++ b/debs/siegfried/debian/changelog
@@ -1,3 +1,12 @@
+siegfried (1.8.0-1) trusty; urgency=medium
+
+  * Build version v1.8.0-1, with custom archivematica configuration
+  * Use DH_GOPKG=github.com/richardlehane/siegfried/cmd...
+    (See https://github.com/richardlehane/siegfried/pull/98)
+  * Use Go 1.13
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Fri, 24 Jan 2020 12:16:33 +0000
+
 siegfried (1.6.7-2) trusty; urgency=medium
 
   * Build version v1.6.7-2, with custom archivematica configuration

--- a/debs/siegfried/debian/rules
+++ b/debs/siegfried/debian/rules
@@ -2,7 +2,7 @@
 
 export DH_OPTIONS
 
-export DH_GOPKG := github.com/richardlehane/siegfried
+export DH_GOPKG := github.com/richardlehane/siegfried/cmd
 
 #export GOROOT := $(CURDIR)/$(BUILD_DIR)/go
 # Tests assume a fixed position for the PRONOM files,

--- a/rpm/siegfried/Dockerfile
+++ b/rpm/siegfried/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:7
 
 # Environmnet variables needed during build
-ENV GOVERSION 1.11
+ENV GOVERSION 1.13
 ENV GOOS linux
 ENV GOARCH amd64
 

--- a/rpm/siegfried/Makefile
+++ b/rpm/siegfried/Makefile
@@ -1,5 +1,5 @@
 NAME          = siegfried
-VERSION       = 1.7.10
+VERSION       = 1.8.0
 RPM_TOPDIR    = "/rpmbuild"
 DOCKER_VOLUME = "/src"
 DOCKER_IMAGE  = "rpmbuild-$(NAME)-$(VERSION)"


### PR DESCRIPTION
* Build version v1.8.0-1, with custom archivematica configuration
* (Ubuntu) Use DH_GOPKG=github.com/richardlehane/siegfried/cmd...
    (See https://github.com/richardlehane/siegfried/pull/98)
* Use Go 1.13

The `DH_GOPKG=github.com/richardlehane/siegfried/cmd...` was
already used on v1.7 CentOS package.

Connects to https://github.com/archivematica/Issues/issues/1075