### PR TITLE
jhove: Increase extraversion in Bionic package

### DIFF
--- a/debs/bionic/jhove/Makefile
+++ b/debs/bionic/jhove/Makefile
@@ -1,6 +1,6 @@
 NAME          = jhove
 VERSION       ?= 1.20.1
-RELEASE	      ?= 1~18.04
+RELEASE	      ?= 6~18.04
 GIT_URL	      = https://github.com/openpreserve/jhove
 DEB_TOPDIR    = "/debbuild"
 DOCKER_VOLUME = "/src"


### PR DESCRIPTION
The official jhove bionic package has been updated and has a greater
extraversion than the artefactual one. This is a workaround till new jhove
v1.24 is released.

Connects to https://github.com/archivematica/Issues/issues/1065