### PR TITLE
Remove clamav-server packages

### DIFF
--- a/rpm/archivematica/archivematica.spec
+++ b/rpm/archivematica/archivematica.spec
@@ -44,15 +44,13 @@ Requires: ImageMagick
 Requires: ghostscript
 Requires: perl-Image-ExifTool
 Requires: inkscape
-Requires: clamav-server
 Requires: clamav-data
 Requires: clamav-update
 Requires: clamav-filesystem
 Requires: clamav
-Requires: clamav-scanner-systemd
 Requires: clamav-devel
 Requires: clamav-lib
-Requires: clamav-server-systemd
+Requires: clamd
 Requires: libvpx
 Requires: libraw1394
 Requires: libpst


### PR DESCRIPTION
Some packages were needed for the transition to systemd, but they aren't available now.

Connects to https://github.com/archivematica/Issues/issues/1119