### PR TITLE
MCPClient: Pin setuptools&wheel versions on Xenial

### DIFF
--- a/debs/xenial/archivematica/Dockerfile
+++ b/debs/xenial/archivematica/Dockerfile
@@ -4,8 +4,6 @@ RUN apt-get update && \
     apt-get install -y dpkg-dev git build-essential wget debhelper \
     devscripts equivs quilt apt-transport-https
 
-RUN wget -O /tmp/pip.py https://bootstrap.pypa.io/get-pip.py && python /tmp/pip.py
-
 RUN wget -O - https://packages.archivematica.org/1.7.x/key.asc |\
     apt-key add - && \
     echo "deb [arch=amd64] http://packages.archivematica.org/1.7.x/ubuntu-externals xenial main" >> /etc/apt/sources.list

--- a/debs/xenial/archivematica/debian-MCPClient/rules
+++ b/debs/xenial/archivematica/debian-MCPClient/rules
@@ -9,4 +9,4 @@ export DH_VIRTUALENV_INSTALL_ROOT=/usr/share/archivematica/virtualenvs
 override_dh_virtualenv:
 	dh_virtualenv --requirements ../archivematicaCommon/requirements/production.txt --skip-install
 	dh_virtualenv --requirements ../dashboard/src/requirements/production.txt --skip-install
-	dh_virtualenv --preinstall "pip==9.0.3" --skip-install
+	dh_virtualenv --preinstall "pip==9.0.3" --preinstall "setuptools==44.1.0" --preinstall "wheel==0.33.6" --skip-install


### PR DESCRIPTION
* Pin setuptools and wheel versions for Xenial
* Remove pip installation from MCPClient Dockerfile.

Connects to https://github.com/artefactual-labs/am-packbuild/issues/260