### PR TITLE
Update changelogs and vagrant box for v1.11.2

### DIFF
--- a/debs/bionic/archivematica-storage-service/debian-storage-service/changelog
+++ b/debs/bionic/archivematica-storage-service/debian-storage-service/changelog
@@ -1,3 +1,10 @@
+archivematica-storage-service (1:0.16.1-1~18.04) bionic; urgency=high
+
+  * commit: 21d8ee943b5f0c4882c649a3d9b11ad2e0528b5b
+  * checkout: v0.16.1
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Fri, 12 Jun 2020 08:47:04 +0000
+
 archivematica-storage-service (1:0.16.0-1~18.04) bionic; urgency=high
 
   * commit: 18b9a77ce1a6789be00159289fb48f4edc46065e

--- a/debs/bionic/archivematica/debian-MCPClient/changelog
+++ b/debs/bionic/archivematica/debian-MCPClient/changelog
@@ -1,3 +1,10 @@
+archivematica-mcp-client (1:1.11.2-1~18.04) bionic; urgency=high
+
+  * commit: 396015a44723e6b2dd2f4d7bed1443514a429c12
+  * checkout: v1.11.2
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Fri, 12 Jun 2020 08:26:12 +0000
+
 archivematica-mcp-client (1:1.11.0-1~18.04) bionic; urgency=high
 
   * commit: 3e52494735ebfeb0cabc477d95d692034f4b3142

--- a/debs/bionic/archivematica/debian-MCPServer/changelog
+++ b/debs/bionic/archivematica/debian-MCPServer/changelog
@@ -1,3 +1,10 @@
+archivematica-mcp-server (1:1.11.2-1~18.04) bionic; urgency=high
+
+  * commit: 396015a44723e6b2dd2f4d7bed1443514a429c12
+  * checkout: v1.11.2
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Fri, 12 Jun 2020 08:27:32 +0000
+
 archivematica-mcp-server (1:1.11.0-1~18.04) bionic; urgency=high
 
   * commit: 3e52494735ebfeb0cabc477d95d692034f4b3142

--- a/debs/bionic/archivematica/debian-archivematicaCommon/changelog
+++ b/debs/bionic/archivematica/debian-archivematicaCommon/changelog
@@ -1,3 +1,17 @@
+archivematica-common (1:1.11.2-1~18.04) bionic; urgency=high
+
+  * commit: 396015a44723e6b2dd2f4d7bed1443514a429c12
+  * checkout: v1.11.2
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Fri, 12 Jun 2020 08:28:36 +0000
+
+archivematica-common (1:1.11.1-1~18.04) bionic; urgency=high
+
+  * commit: aeaf62b004d0ff5ea6fc2c56bc6291680b6c779e
+  * checkout: stable/1.11.x
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Mon, 18 May 2020 18:37:31 +0000
+
 archivematica-common (1:1.11.0-1~18.04) bionic; urgency=high
 
   * commit: 3e52494735ebfeb0cabc477d95d692034f4b3142

--- a/debs/bionic/archivematica/debian-dashboard/changelog
+++ b/debs/bionic/archivematica/debian-dashboard/changelog
@@ -1,3 +1,17 @@
+archivematica-dashboard (1:1.11.2-1~18.04) bionic; urgency=high
+
+  * commit: 396015a44723e6b2dd2f4d7bed1443514a429c12
+  * checkout: v1.11.2
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Fri, 12 Jun 2020 08:22:44 +0000
+
+archivematica-dashboard (1:1.11.1-1~18.04) bionic; urgency=high
+
+  * commit: aeaf62b004d0ff5ea6fc2c56bc6291680b6c779e
+  * checkout: stable/1.11.x
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Mon, 18 May 2020 18:31:38 +0000
+
 archivematica-dashboard (1:1.11.0-1~18.04) bionic; urgency=high
 
   * commit: 3e52494735ebfeb0cabc477d95d692034f4b3142

--- a/debs/xenial/archivematica-storage-service/debian-storage-service/changelog
+++ b/debs/xenial/archivematica-storage-service/debian-storage-service/changelog
@@ -1,3 +1,10 @@
+archivematica-storage-service (1:0.16.1-1~16.04) xenial; urgency=high
+
+  * commit: 21d8ee943b5f0c4882c649a3d9b11ad2e0528b5b
+  * checkout: v0.16.1
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Fri, 12 Jun 2020 08:47:19 +0000
+
 archivematica-storage-service (1:0.16.0-1~16.04) xenial; urgency=high
 
   * commit: 18b9a77ce1a6789be00159289fb48f4edc46065e

--- a/debs/xenial/archivematica/debian-MCPClient/changelog
+++ b/debs/xenial/archivematica/debian-MCPClient/changelog
@@ -1,3 +1,10 @@
+archivematica-mcp-client (1:1.11.2-1~16.04) xenial; urgency=high
+
+  * commit: 396015a44723e6b2dd2f4d7bed1443514a429c12
+  * checkout: v1.11.2
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Fri, 12 Jun 2020 08:26:57 +0000
+
 archivematica-mcp-client (1:1.11.0-1~16.04) xenial; urgency=high
 
   * commit: 3e52494735ebfeb0cabc477d95d692034f4b3142

--- a/debs/xenial/archivematica/debian-MCPServer/changelog
+++ b/debs/xenial/archivematica/debian-MCPServer/changelog
@@ -1,3 +1,10 @@
+archivematica-mcp-server (1:1.11.2-1~16.04) xenial; urgency=high
+
+  * commit: 396015a44723e6b2dd2f4d7bed1443514a429c12
+  * checkout: v1.11.2
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Fri, 12 Jun 2020 08:29:01 +0000
+
 archivematica-mcp-server (1:1.11.0-1~16.04) xenial; urgency=high
 
   * commit: 3e52494735ebfeb0cabc477d95d692034f4b3142

--- a/debs/xenial/archivematica/debian-archivematicaCommon/changelog
+++ b/debs/xenial/archivematica/debian-archivematicaCommon/changelog
@@ -1,3 +1,17 @@
+archivematica-common (1:1.11.2-1~16.04) xenial; urgency=high
+
+  * commit: 396015a44723e6b2dd2f4d7bed1443514a429c12
+  * checkout: v1.11.2
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Fri, 12 Jun 2020 08:30:28 +0000
+
+archivematica-common (1:1.11.1-1~16.04) xenial; urgency=high
+
+  * commit: aeaf62b004d0ff5ea6fc2c56bc6291680b6c779e
+  * checkout: stable/1.11.x
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Mon, 18 May 2020 18:48:52 +0000
+
 archivematica-common (1:1.11.0-1~16.04) xenial; urgency=high
 
   * commit: 3e52494735ebfeb0cabc477d95d692034f4b3142

--- a/debs/xenial/archivematica/debian-dashboard/changelog
+++ b/debs/xenial/archivematica/debian-dashboard/changelog
@@ -1,3 +1,17 @@
+archivematica-dashboard (1:1.11.2-1~16.04) xenial; urgency=high
+
+  * commit: 396015a44723e6b2dd2f4d7bed1443514a429c12
+  * checkout: v1.11.2
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Fri, 12 Jun 2020 08:23:02 +0000
+
+archivematica-dashboard (1:1.11.1-1~16.04) xenial; urgency=high
+
+  * commit: aeaf62b004d0ff5ea6fc2c56bc6291680b6c779e
+  * checkout: stable/1.11.x
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Mon, 18 May 2020 18:41:39 +0000
+
 archivematica-dashboard (1:1.11.0-1~16.04) xenial; urgency=high
 
   * commit: 3e52494735ebfeb0cabc477d95d692034f4b3142

--- a/packer/templates/vagrant-box-archivematica/provisioning/singlenode.yml
+++ b/packer/templates/vagrant-box-archivematica/provisioning/singlenode.yml
@@ -4,8 +4,8 @@
   vars:
     # archivematica-src role
     - archivematica_src_install_devtools: "yes"
-    - archivematica_src_am_version: "v1.11.0"
-    - archivematica_src_ss_version: "v0.16.0"
+    - archivematica_src_am_version: "v1.11.2"
+    - archivematica_src_ss_version: "v0.16.1"
     - archivematica_src_ss_gunicorn: "true"
     - archivematica_src_am_dashboard_gunicorn: "true"
     - archivematica_src_am_multi_venvs: "true"

--- a/rpm/archivematica-storage-service/changelog
+++ b/rpm/archivematica-storage-service/changelog
@@ -1,4 +1,7 @@
 %changelog
+* Fri Jun 12 2020 Artefactual <sysadmin@artefactual.com> - 0.16.1-1
+- Packbuild: 2092ee13770b6730daf8789473a146d7492f996b
+- Storage Service: 21d8ee943b5f0c4882c649a3d9b11ad2e0528b5b
 * Tue Mar 31 2020 Artefactual <sysadmin@artefactual.com> - 0.16.0-1
 - Packbuild: 7d0527383fb0d11ddd2538c2ba4130f1b293b0ab
 - Storage Service: 18b9a77ce1a6789be00159289fb48f4edc46065e

--- a/rpm/archivematica/changelog
+++ b/rpm/archivematica/changelog
@@ -1,5 +1,11 @@
 %changelog
-* Tue Mar 31 2020 Artefactual <sysadmin@artefactual.com> - 0.16.0-1
+* Fri Jun 12 2020 Artefactual <sysadmin@artefactual.com> - 1.11.2-1
+- Packbuild: 2092ee13770b6730daf8789473a146d7492f996b
+- Archivematica: 396015a44723e6b2dd2f4d7bed1443514a429c12
+* Fri Jun 12 2020 Artefactual <sysadmin@artefactual.com> - 1.11.1-1
+- Packbuild: 53f22efb52fc2309c0433d49787534918e487522
+- Archivematica: 0722067836c3430f2a371f15583be633a6db7fe5
+* Tue Mar 31 2020 Artefactual <sysadmin@artefactual.com> - 1.11.0-1
 - Packbuild: 7d0527383fb0d11ddd2538c2ba4130f1b293b0ab
 - Archivematica: 3e52494735ebfeb0cabc477d95d692034f4b3142
 * Wed Jan 09 2019 - sysadmin@artefactual.com


### PR DESCRIPTION
- Update AM vagrant box version
- Fix typo in rpm 1.11.0-1 changelog
- Update packages changelogs for versions 1.11.1 and 1.11.2

AM1.11.1 packages:

Bionic AM: https://jenkins-ci.archivematica.org/job/am-packbuild/job/bionic-jenkinsci/248/
Xenial AM: https://jenkins-ci.archivematica.org/job/am-packbuild/job/xenial-jenkinsci/226/
CentOS AM: https://jenkins-ci.archivematica.org/job/am-packbuild/job/rpm-jenkinsci/428/

AM1.11.2 packages:

Xenial SS: https://jenkins-ci.archivematica.org/job/am-packbuild/job/xenial-jenkinsci/245/
Xenial AM: https://jenkins-ci.archivematica.org/job/am-packbuild/job/xenial-jenkinsci/244/
Bionic SS: https://jenkins-ci.archivematica.org/job/am-packbuild/job/bionic-jenkinsci/262/
Bionic AM: https://jenkins-ci.archivematica.org/job/am-packbuild/job/bionic-jenkinsci/261/
CentOS SS: https://jenkins-ci.archivematica.org/job/am-packbuild/job/rpm-jenkinsci/448/
Centos AM: https://jenkins-ci.archivematica.org/job/am-packbuild/job/rpm-jenkinsci/447/

Connects to https://github.com/archivematica/Issues/issues/1217