### PR TITLE
rpm: Use %config(noreplace) instead of %config

### DIFF
--- a/rpm/archivematica-storage-service/package.spec
+++ b/rpm/archivematica-storage-service/package.spec
@@ -22,10 +22,10 @@ The Storage Service is the mechanism by which Archivematica is able to store pac
 /var/archivematica/storage-service/
 /var/archivematica/storage_service/
 /usr/lib/systemd/system/archivematica-storage-service.service
-%config /etc/sysconfig/archivematica-storage-service
-%config /etc/nginx/conf.d/archivematica-storage-service.conf
-%config /etc/archivematica/storage-service.gunicorn-config.py
-%config /etc/archivematica/storageService.logging.json
+%config(noreplace) /etc/sysconfig/archivematica-storage-service
+%config(noreplace) /etc/nginx/conf.d/archivematica-storage-service.conf
+%config(noreplace) /etc/archivematica/storage-service.gunicorn-config.py
+%config(noreplace) /etc/archivematica/storageService.logging.json
 
 %prep
 rm -rf /usr/share/python/archivematica-storage-service

--- a/rpm/archivematica/archivematica.spec
+++ b/rpm/archivematica/archivematica.spec
@@ -101,28 +101,28 @@ Archivematica dashboard with Nginx + gunicorn.
 /usr/share/archivematica/virtualenvs/archivematica-mcp-server/
 /usr/lib/archivematica/MCPServer/
 /usr/lib/systemd/system/archivematica-mcp-server.service
-%config /etc/sysconfig/archivematica-mcp-server
-%config /etc/archivematica/serverConfig.conf
-%config /etc/archivematica/serverConfig.logging.json
+%config(noreplace) /etc/sysconfig/archivematica-mcp-server
+%config(noreplace) /etc/archivematica/serverConfig.conf
+%config(noreplace) /etc/archivematica/serverConfig.logging.json
 
 # MCPClient
 %files mcp-client
 /usr/share/archivematica/virtualenvs/archivematica-mcp-client/
 /usr/lib/archivematica/MCPClient/
 /usr/lib/systemd/system/archivematica-mcp-client.service
-%config /etc/sysconfig/archivematica-mcp-client
-%config /etc/archivematica/clientConfig.conf
-%config /etc/archivematica/clientConfig.logging.json
+%config(noreplace) /etc/sysconfig/archivematica-mcp-client
+%config(noreplace) /etc/archivematica/clientConfig.conf
+%config(noreplace) /etc/archivematica/clientConfig.logging.json
 
 # Dashboard
 %files dashboard
 /usr/share/archivematica/virtualenvs/archivematica-dashboard/
 /usr/share/archivematica/dashboard/
 /usr/lib/systemd/system/archivematica-dashboard.service
-%config /etc/sysconfig/archivematica-dashboard
-%config /etc/nginx/conf.d/archivematica-dashboard.conf
-%config /etc/archivematica/dashboard.gunicorn-config.py
-%config /etc/archivematica/dashboard.logging.json
+%config(noreplace) /etc/sysconfig/archivematica-dashboard
+%config(noreplace) /etc/nginx/conf.d/archivematica-dashboard.conf
+%config(noreplace) /etc/archivematica/dashboard.gunicorn-config.py
+%config(noreplace) /etc/archivematica/dashboard.logging.json
 
 #
 # Preparations


### PR DESCRIPTION
When a config file that uses the `%config` macro is changed in the rpm package
(for instance a new variable was added to the config file for the latest
version), if this package is updated: the config file is overwritten with the
new config file from the rpm, and a `.rpmsave` file is created with the old
config file.

Using the `%config(noreplace)` macro in the above situation: the old
configuration file is kept and the new rpm default config file is created as a
`.rpmnew` file.

More info: https://www.cl.cam.ac.uk/~jw35/docs/rpm_config.html

Connects to https://github.com/archivematica/Issues/issues/1236