### PR TITLE
AtoM Ubuntu 20.04 LTS base box

### DIFF
--- a/packer/http/ubuntu-20.04/preseed.cfg
+++ b/packer/http/ubuntu-20.04/preseed.cfg
@@ -1,0 +1,40 @@
+choose-mirror-bin mirror/http/proxy string
+d-i base-installer/kernel/override-image string linux-server
+d-i clock-setup/utc boolean true
+d-i clock-setup/utc-auto boolean true
+d-i finish-install/reboot_in_progress note
+d-i grub-installer/only_debian boolean true
+d-i grub-installer/with_other_os boolean true
+d-i partman-auto/disk string /dev/sda
+d-i partman-auto-lvm/guided_size string max
+d-i partman-auto/choose_recipe select atomic
+d-i partman-auto/method string lvm
+d-i partman-lvm/confirm boolean true
+d-i partman-lvm/confirm boolean true
+d-i partman-lvm/confirm_nooverwrite boolean true
+d-i partman-lvm/device_remove_lvm boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+d-i partman/confirm_write_new_label boolean true
+d-i pkgsel/include string openssh-server cryptsetup build-essential libssl-dev libreadline-dev zlib1g-dev linux-source dkms nfs-common
+d-i pkgsel/install-language-support boolean false
+d-i pkgsel/update-policy select none
+d-i pkgsel/upgrade select full-upgrade
+d-i time/zone string UTC
+tasksel tasksel/first multiselect standard, ubuntu-server
+
+d-i console-setup/ask_detect boolean false
+d-i keyboard-configuration/layoutcode string us
+d-i keyboard-configuration/modelcode string pc105
+d-i debian-installer/locale string en_US.UTF-8
+
+# Create vagrant user account.
+d-i passwd/user-fullname string vagrant
+d-i passwd/username string vagrant
+d-i passwd/user-password password vagrant
+d-i passwd/user-password-again password vagrant
+d-i user-setup/allow-password-weak boolean true
+d-i user-setup/encrypt-home boolean false
+d-i passwd/user-default-groups vagrant sudo
+d-i passwd/user-uid string 900

--- a/packer/scripts/ubuntu/cleanup.sh
+++ b/packer/scripts/ubuntu/cleanup.sh
@@ -40,7 +40,7 @@ apt-get -y purge libx11-data xauth libxmuu1 libxcb1 libx11-6 libxext6;
 apt-get -y purge ppp pppconfig pppoeconf;
 
 # Delete oddities
-apt-get -y purge popularity-contest installation-report command-not-found command-not-found-data friendly-recovery;
+apt-get -y purge popularity-contest installation-report command-not-found friendly-recovery;
 
 apt-get -y autoremove;
 apt-get -y clean;
@@ -57,5 +57,3 @@ find /var/cache -type f -exec rm -rf {} \;
 # delete any logs that have built up during the install
 #find /var/log/ -name *.log -exec rm -f {} \;
 find /var/log/ -type f -iname '*.log' | grep -v archivematica | xargs -i{} rm -f {}
-
-

--- a/packer/scripts/ubuntu/networking.sh
+++ b/packer/scripts/ubuntu/networking.sh
@@ -12,6 +12,3 @@ if [ "$major_version" -le "15" ]; then
   rm -f /lib/udev/rules.d/75-persistent-net-generator.rules;
   rm -rf /dev/.udev/ /var/lib/dhcp3/* /var/lib/dhcp/*;
 fi
-
-# Adding a 2 sec delay to the interface up, to make the dhclient happy
-echo "pre-up sleep 2" >>/etc/network/interfaces;

--- a/packer/scripts/ubuntu/update.sh
+++ b/packer/scripts/ubuntu/update.sh
@@ -15,14 +15,6 @@ sed -i.bak 's/^Prompt=.*$/Prompt=never/' /etc/update-manager/release-upgrades;
 # Update the package list
 apt-get -y update;
 
-# update package index on boot
-cat <<EOF >/etc/init/refresh-apt.conf;
-description "update package index"
-start on networking
-task
-exec /usr/bin/apt-get update
-EOF
-
 # Manage broken indexes on distro disc 12.04.5
 if [ "$ubuntu_version" = "12.04" ]; then
     apt-get -y install libreadline-dev dpkg;

--- a/packer/templates/vagrant-base-ubuntu-20.04-amd64/template.json
+++ b/packer/templates/vagrant-base-ubuntu-20.04-amd64/template.json
@@ -1,0 +1,110 @@
+{
+  "builders": [
+    {
+      "boot_command": [
+        "<enter><wait><f6><esc><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "/install/vmlinuz<wait>",
+        " auto<wait>",
+        " console-setup/ask_detect=false<wait>",
+        " console-setup/layoutcode=us<wait>",
+        " console-setup/modelcode=pc105<wait>",
+        " debconf/frontend=noninteractive<wait>",
+        " debian-installer=en_US.UTF-8<wait>",
+        " fb=false<wait>",
+        " initrd=/install/initrd.gz<wait>",
+        " kbd-chooser/method=us<wait>",
+        " keyboard-configuration/layout=USA<wait>",
+        " keyboard-configuration/variant=USA<wait>",
+        " locale=en_US.UTF-8<wait>",
+        " netcfg/get_domain=vm<wait>",
+        " netcfg/get_hostname=vagrant<wait>",
+        " grub-installer/bootdev=/dev/sda<wait>",
+        " noapic<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg<wait>",
+        " -- <wait>",
+        "<enter><wait>"
+      ],
+      "boot_wait": "10s",
+      "disk_size": "{{user `disk_size`}}",
+      "guest_os_type": "Ubuntu_64",
+      "hard_drive_interface": "sata",
+      "headless": "{{ user `headless` }}",
+      "http_directory": "../../http/ubuntu-20.04",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_urls": [
+        "iso/ubuntu-20.04.1-legacy-server-amd64.iso",
+        "http://cdimage.ubuntu.com/ubuntu-legacy-server/releases/20.04.1/release/ubuntu-20.04.1-legacy-server-amd64.iso"
+       ],
+      "output_directory": "../../builds/virtualbox/vagrant-base-ubuntu-20.04-amd64",
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "virtualbox-iso",
+      "vboxmanage": [
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "{{ user `memory` }}"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "{{ user `cpus` }}"
+        ]
+      ],
+      "virtualbox_version_file": ".vbox_version",
+      "vm_name": "{{ user `template` }}"
+    }
+  ],
+  "provisioners": [
+     {
+      "environment_vars": [
+        "HOME_DIR=/home/vagrant",
+        "http_proxy={{user `http_proxy`}}",
+        "https_proxy={{user `https_proxy`}}",
+        "no_proxy={{user `no_proxy`}}"
+      ],
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true,
+      "scripts": [
+        "../../scripts/ubuntu/update.sh",
+        "../../scripts/common/sshd.sh",
+        "../../scripts/ubuntu/networking.sh",
+        "../../scripts/ubuntu/sudoers.sh",
+        "../../scripts/ubuntu/vagrant.sh",
+        "../../scripts/common/virtualbox.sh",
+        "../../scripts/ubuntu/cleanup.sh",
+        "../../scripts/common/minimize.sh"
+      ],
+      "type": "shell"
+    }
+  ],
+  "variables": {
+    "box_basename": "ubuntu-20.04",
+    "build_timestamp": "{{isotime}}",
+    "cpus": "2",
+    "disk_size": "20960",
+    "git_revision": "__unknown_git_revision__",
+    "headless": "true",
+    "http_proxy": "{{env `http_proxy`}}",
+    "https_proxy": "{{env `https_proxy`}}",
+    "iso_checksum": "f11bda2f2caed8f420802b59f382c25160b114ccc665dbac9c5046e7fceaced2",
+    "iso_name": "ubuntu-20.04.1-legacy-server-amd64.iso",
+    "memory": "4096",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://cdimage.ubuntu.com/ubuntu-legacy-server/releases",
+    "mirror_directory": "20.04.1/release/",
+    "name": "ubuntu-20.04",
+    "no_proxy": "{{env `no_proxy`}}",
+    "preseed_path": "../../http/ubuntu-20.04/preseed.cfg",
+    "template": "vagrant-base-ubuntu-20.04-amd64",
+    "version": "2.1.TIMESTAMP"
+  }
+}


### PR DESCRIPTION
Add Ubuntu 20.04 base box in am-packbuild for AtoM.

Note that this is using the legacy server ISO. The legacy ISO still uses
the Debian installer so is compatible with the 18.04 preseed.cfg files.
Going forward this will be removed and replaced with Subiquity installer
which will require re-implmenting the scripts.