### PR TITLE
acmetool: Use /usr/bin path for Ubuntu binaries

### DIFF
--- a/debs/bionic/acmetool/Makefile
+++ b/debs/bionic/acmetool/Makefile
@@ -1,6 +1,6 @@
 NAME          = acmetool
 VERSION       ?= 0.2.1
-RELEASE	      ?= 1~18.04
+RELEASE	      ?= 2~18.04
 GIT_URL	      = https://github.com/hlandau/acmetool
 GPG_ID        ?= 5236CA08
 DEB_TOPDIR    = "/debbuild"

--- a/debs/bionic/acmetool/debian/changelog
+++ b/debs/bionic/acmetool/debian/changelog
@@ -1,3 +1,9 @@
+acmetool (0.2.1-2~18.04) bionic; urgency=medium
+
+  * Use /usr/bin path instead of /bin for binary.
+
+ -- Artefactual Sysadmin <sysadmin@artefactual.com>  Tue, 27 Aug 2020 12:15:36 +0100
+
 acmetool (0.2.1-1~18.04) bionic; urgency=medium
 
   * Acmetool 0.2.1 release

--- a/debs/bionic/acmetool/debian/rules
+++ b/debs/bionic/acmetool/debian/rules
@@ -19,8 +19,8 @@ override_dh_auto_build :
 override_dh_auto_test:
 
 override_dh_auto_install:
-	mkdir -p debian/acmetool/bin
-	cp bin/acmetool debian/acmetool/bin/
+	mkdir -p debian/acmetool/usr/bin
+	cp bin/acmetool debian/acmetool/usr/bin/
 
 override_dh_installman:
 	mkdir -p debian/acmetool/usr/share/man/man8

--- a/debs/xenial/acmetool/Makefile
+++ b/debs/xenial/acmetool/Makefile
@@ -1,6 +1,6 @@
 NAME          = acmetool
 VERSION       ?= 0.2.1
-RELEASE	      ?= 1~16.04
+RELEASE	      ?= 2~16.04
 GIT_URL	      = https://github.com/hlandau/acmetool
 GPG_ID        ?= 5236CA08
 DEB_TOPDIR    = "/debbuild"

--- a/debs/xenial/acmetool/debian/changelog
+++ b/debs/xenial/acmetool/debian/changelog
@@ -1,3 +1,9 @@
+acmetool (0.2.1-2~16.04) xenial; urgency=medium
+
+  * Use /usr/bin path instead of /bin for binary.
+
+ -- Artefactual Sysadmin <sysadmin@artefactual.com>  Tue, 27 Aug 2020 12:15:36 +0100
+
 acmetool (0.2.1-1~16.04) xenial; urgency=medium
 
   * Acmetool 0.2.1 release

--- a/debs/xenial/acmetool/debian/rules
+++ b/debs/xenial/acmetool/debian/rules
@@ -19,8 +19,8 @@ override_dh_auto_build :
 override_dh_auto_test:
 
 override_dh_auto_install:
-	mkdir -p debian/acmetool/bin
-	cp bin/acmetool debian/acmetool/bin/
+	mkdir -p debian/acmetool/usr/bin
+	cp bin/acmetool debian/acmetool/usr/bin/
 
 override_dh_installman:
 	mkdir -p debian/acmetool/usr/share/man/man8


### PR DESCRIPTION
Connects to https://github.com/artefactual-labs/ansible-acmetool/issues/17