### PR TITLE
rpm: Remove font-awesome's symlink on dashboard

### DIFF
--- a/rpm/archivematica/archivematica.spec
+++ b/rpm/archivematica/archivematica.spec
@@ -214,6 +214,10 @@ cp -rf /usr/share/archivematica/virtualenvs/archivematica-dashboard/* %{buildroo
 
 cp -rf %{_sourcedir}/%{name}/src/dashboard/src/* %{buildroot}/usr/share/archivematica/dashboard/
 
+# Remove font-awesome's symlink and copy its directory from frontend dir
+rm %{buildroot}/usr/share/archivematica/dashboard/media/vendor/font-awesome
+cp -rf %{_sourcedir}/%{name}/src/dashboard/frontend/node_modules/font-awesome %{buildroot}/usr/share/archivematica/dashboard/media/vendor/font-awesome
+
 cp %{_sourcedir}/%{name}/src/dashboard/install/dashboard.gunicorn-config.py %{buildroot}/etc/archivematica/dashboard.gunicorn-config.py
 cp %{_sourcedir}/%{name}/src/dashboard/install/dashboard.logging.json %{buildroot}/etc/archivematica/dashboard.logging.json
 cp %{_etcdir}/archivematica-dashboard.service %{buildroot}/usr/lib/systemd/system/archivematica-dashboard.service


### PR DESCRIPTION
When creating static content there's a broken symlink for font-awesome, that
points to `../../../frontend/node_modules/font-awesome/`.

https://github.com/artefactual/archivematica/blob/qa/1.x/src/dashboard/src/media/vendor/font-awesome

The rpm dashboard package has a different directory structure than
archivematica source code, and the `frontend` directory is not included in the
package.

This PR removes the symlink and copies the `awesome-font` directory from
the `frontend` directory.

Connects to https://github.com/archivematica/Issues/issues/1300