### PR TITLE
Update changelogs and vagrant box for v1.12.0

### DIFF
--- a/debs/bionic/archivematica-storage-service/debian-storage-service/changelog
+++ b/debs/bionic/archivematica-storage-service/debian-storage-service/changelog
@@ -1,3 +1,10 @@
+archivematica-storage-service (1:0.17.0-1~18.04) bionic; urgency=high
+
+  * commit: 6bf42f090b779e436203d24dc76e26f4c051e73d
+  * checkout: v0.17.0
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Tue, 06 Oct 2020 16:34:38 +0000
+
 archivematica-storage-service (1:0.16.1-1~18.04) bionic; urgency=high
 
   * commit: 21d8ee943b5f0c4882c649a3d9b11ad2e0528b5b

--- a/debs/bionic/archivematica/debian-MCPClient/changelog
+++ b/debs/bionic/archivematica/debian-MCPClient/changelog
@@ -1,3 +1,10 @@
+archivematica-mcp-client (1:1.12.0-1~18.04) bionic; urgency=high
+
+  * commit: c5e7a0fb4aaaf5d30d20e46707b66f788d7a0fba
+  * checkout: v1.12.0
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Tue, 06 Oct 2020 16:30:05 +0000
+
 archivematica-mcp-client (1:1.11.2-1~18.04) bionic; urgency=high
 
   * commit: 396015a44723e6b2dd2f4d7bed1443514a429c12

--- a/debs/bionic/archivematica/debian-MCPServer/changelog
+++ b/debs/bionic/archivematica/debian-MCPServer/changelog
@@ -1,3 +1,10 @@
+archivematica-mcp-server (1:1.12.0-1~18.04) bionic; urgency=high
+
+  * commit: c5e7a0fb4aaaf5d30d20e46707b66f788d7a0fba
+  * checkout: v1.12.0
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Tue, 06 Oct 2020 16:31:49 +0000
+
 archivematica-mcp-server (1:1.11.2-1~18.04) bionic; urgency=high
 
   * commit: 396015a44723e6b2dd2f4d7bed1443514a429c12

--- a/debs/bionic/archivematica/debian-archivematicaCommon/changelog
+++ b/debs/bionic/archivematica/debian-archivematicaCommon/changelog
@@ -1,3 +1,10 @@
+archivematica-common (1:1.12.0-1~18.04) bionic; urgency=high
+
+  * commit: c5e7a0fb4aaaf5d30d20e46707b66f788d7a0fba
+  * checkout: v1.12.0
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Tue, 06 Oct 2020 16:33:40 +0000
+
 archivematica-common (1:1.11.2-1~18.04) bionic; urgency=high
 
   * commit: 396015a44723e6b2dd2f4d7bed1443514a429c12

--- a/debs/bionic/archivematica/debian-dashboard/changelog
+++ b/debs/bionic/archivematica/debian-dashboard/changelog
@@ -1,3 +1,10 @@
+archivematica-dashboard (1:1.12.0-1~18.04) bionic; urgency=high
+
+  * commit: c5e7a0fb4aaaf5d30d20e46707b66f788d7a0fba
+  * checkout: v1.12.0
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Tue, 06 Oct 2020 16:25:53 +0000
+
 archivematica-dashboard (1:1.11.2-1~18.04) bionic; urgency=high
 
   * commit: 396015a44723e6b2dd2f4d7bed1443514a429c12

--- a/debs/xenial/archivematica-storage-service/debian-storage-service/changelog
+++ b/debs/xenial/archivematica-storage-service/debian-storage-service/changelog
@@ -1,3 +1,10 @@
+archivematica-storage-service (1:0.17.0-1~16.04) xenial; urgency=high
+
+  * commit: 6bf42f090b779e436203d24dc76e26f4c051e73d
+  * checkout: v0.17.0
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Tue, 06 Oct 2020 16:36:07 +0000
+
 archivematica-storage-service (1:0.16.1-1~16.04) xenial; urgency=high
 
   * commit: 21d8ee943b5f0c4882c649a3d9b11ad2e0528b5b

--- a/debs/xenial/archivematica/debian-MCPClient/changelog
+++ b/debs/xenial/archivematica/debian-MCPClient/changelog
@@ -1,3 +1,10 @@
+archivematica-mcp-client (1:1.12.0-1~16.04) xenial; urgency=high
+
+  * commit: c5e7a0fb4aaaf5d30d20e46707b66f788d7a0fba
+  * checkout: v1.12.0
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Tue, 06 Oct 2020 16:41:18 +0000
+
 archivematica-mcp-client (1:1.11.2-1~16.04) xenial; urgency=high
 
   * commit: 396015a44723e6b2dd2f4d7bed1443514a429c12

--- a/debs/xenial/archivematica/debian-MCPServer/changelog
+++ b/debs/xenial/archivematica/debian-MCPServer/changelog
@@ -1,3 +1,10 @@
+archivematica-mcp-server (1:1.12.0-1~16.04) xenial; urgency=high
+
+  * commit: c5e7a0fb4aaaf5d30d20e46707b66f788d7a0fba
+  * checkout: v1.12.0
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Tue, 06 Oct 2020 16:44:47 +0000
+
 archivematica-mcp-server (1:1.11.2-1~16.04) xenial; urgency=high
 
   * commit: 396015a44723e6b2dd2f4d7bed1443514a429c12

--- a/debs/xenial/archivematica/debian-archivematicaCommon/changelog
+++ b/debs/xenial/archivematica/debian-archivematicaCommon/changelog
@@ -1,3 +1,10 @@
+archivematica-common (1:1.12.0-1~16.04) xenial; urgency=high
+
+  * commit: c5e7a0fb4aaaf5d30d20e46707b66f788d7a0fba
+  * checkout: v1.12.0
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Tue, 06 Oct 2020 16:47:55 +0000
+
 archivematica-common (1:1.11.2-1~16.04) xenial; urgency=high
 
   * commit: 396015a44723e6b2dd2f4d7bed1443514a429c12

--- a/debs/xenial/archivematica/debian-dashboard/changelog
+++ b/debs/xenial/archivematica/debian-dashboard/changelog
@@ -1,3 +1,10 @@
+archivematica-dashboard (1:1.12.0-1~16.04) xenial; urgency=high
+
+  * commit: c5e7a0fb4aaaf5d30d20e46707b66f788d7a0fba
+  * checkout: v1.12.0
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Tue, 06 Oct 2020 16:35:14 +0000
+
 archivematica-dashboard (1:1.11.2-1~16.04) xenial; urgency=high
 
   * commit: 396015a44723e6b2dd2f4d7bed1443514a429c12

--- a/packer/scripts/common/minimize.sh
+++ b/packer/scripts/common/minimize.sh
@@ -3,6 +3,12 @@ case "$PACKER_BUILDER_TYPE" in
   qemu) exit 0 ;;
 esac
 
+# Stop eleasticsearch in case it is up to avoid to set the indices in read-only mode 
+# Because the whiteout tasks are going to use the complete disk
+if (systemctl -q is-active elasticsearch.service); then
+    service elasticsearch stop 
+fi
+
 # Whiteout root
 count=$(df --sync -kP / | tail -n1  | awk -F ' ' '{print $4}')
 count=$(($count-1))

--- a/packer/templates/vagrant-box-archivematica/provisioning/singlenode.yml
+++ b/packer/templates/vagrant-box-archivematica/provisioning/singlenode.yml
@@ -4,11 +4,28 @@
   vars:
     # archivematica-src role
     - archivematica_src_install_devtools: "yes"
-    - archivematica_src_am_version: "v1.11.2"
-    - archivematica_src_ss_version: "v0.16.1"
+    - archivematica_src_am_version: "v1.12.0"
+    - archivematica_src_ss_version: "v0.17.0"
     - archivematica_src_ss_gunicorn: "true"
     - archivematica_src_am_dashboard_gunicorn: "true"
     - archivematica_src_am_multi_venvs: "true"
+    - archivematica_src_ss_environment:
+        EMAIL_HOST: "localhost"
+        EMAIL_HOST_PASSWORD: ""
+        EMAIL_HOST_USER: ""
+        EMAIL_PORT: "25"
+    - archivematica_src_am_mcpclient_environment:
+        ARCHIVEMATICA_MCPCLIENT_EMAIL_BACKEND: "django.core.mail.backends.smtp.EmailBackend"
+        ARCHIVEMATICA_MCPCLIENT_EMAIL_HOST: "127.0.0.1"
+        ARCHIVEMATICA_MCPCLIENT_EMAIL_PORT: "25"
+        ARCHIVEMATICA_MCPCLIENT_EMAIL_USE_TLS: "False"
+        ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_ELASTICSEARCHTIMEOUT: "300"
+        ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_STORAGE_SERVICE_CLIENT_QUICK_TIMEOUT: "30"
+    - archivematica_src_am_mcpserver_environment:
+        ARCHIVEMATICA_MCPSERVER_MCPSERVER_STORAGE_SERVICE_CLIENT_QUICK_TIMEOUT: "30"
+        ARCHIVEMATICA_MCPSERVER_MCPSERVER_CONCURRENT_PACKAGES: "20"
+    - archivematica_src_am_dashboard_environment:
+        ARCHIVEMATICA_DASHBOARD_DASHBOARD_STORAGE_SERVICE_CLIENT_QUICK_TIMEOUT: "30"
     # elasticsearch role
     - elasticsearch_version: "6.5.4"
     - elasticsearch_apt_java_package: "openjdk-8-jre-headless"
@@ -48,6 +65,9 @@
     - archivematica_src_configure_am_user: "admin"
     - archivematica_src_configure_am_password: "archivematica"
     - archivematica_src_configure_am_email: "admin@example.com"
+    - archivematica_src_configure_am_api_key: "this_is_the_am_api_key"
+    - archivematica_src_configure_ss_api_key: "this_is_the_ss_api_key"
+
 
   pre_tasks:
 

--- a/packer/templates/vagrant-box-archivematica/requirements.yml
+++ b/packer/templates/vagrant-box-archivematica/requirements.yml
@@ -21,5 +21,5 @@
   name: "artefactual.gearman"
 
 - src: "https://github.com/artefactual-labs/ansible-archivematica-src"
-  version: "stable/1.11.x"
+  version: "stable/1.12.x"
   name: "artefactual.archivematica-src"

--- a/rpm/archivematica-storage-service/changelog
+++ b/rpm/archivematica-storage-service/changelog
@@ -1,4 +1,7 @@
 %changelog
+* Tue Oct 06 2020 Artefactual <sysadmin@artefactual.com> - 0.17.0-1
+- Packbuild: b55d0f63b1b369e4c5a71be13d7deeb6bb9ea7b9
+- Storage Service: 6bf42f090b779e436203d24dc76e26f4c051e73d
 * Fri Jun 12 2020 Artefactual <sysadmin@artefactual.com> - 0.16.1-1
 - Packbuild: 2092ee13770b6730daf8789473a146d7492f996b
 - Storage Service: 21d8ee943b5f0c4882c649a3d9b11ad2e0528b5b

--- a/rpm/archivematica/changelog
+++ b/rpm/archivematica/changelog
@@ -1,4 +1,7 @@
 %changelog
+* Tue Oct 06 2020 Artefactual <sysadmin@artefactual.com> - 1.12.0-1
+- Packbuild: b55d0f63b1b369e4c5a71be13d7deeb6bb9ea7b9
+- Archivematica: c5e7a0fb4aaaf5d30d20e46707b66f788d7a0fba
 * Fri Jun 12 2020 Artefactual <sysadmin@artefactual.com> - 1.11.2-1
 - Packbuild: 2092ee13770b6730daf8789473a146d7492f996b
 - Archivematica: 396015a44723e6b2dd2f4d7bed1443514a429c12


### PR DESCRIPTION
* Update AM vagrant box version
* Stop elasticsearch in packer script to avoid ES indices in read-only
* Update packages changelogs for version 1.12.0

Bionic SS: https://jenkins-ci.archivematica.org/job/am-packbuild/job/bionic-jenkinsci/314/
Bionic AM: https://jenkins-ci.archivematica.org/job/am-packbuild/job/bionic-jenkinsci/312/

Xenial SS: https://jenkins-ci.archivematica.org/job/am-packbuild/job/xenial-jenkinsci/297/
Xenial AM: https://jenkins-ci.archivematica.org/job/am-packbuild/job/xenial-jenkinsci/298/

CentOS SS: https://jenkins-ci.archivematica.org/job/am-packbuild/job/rpm-jenkinsci/501/
CentOS AM: https://jenkins-ci.archivematica.org/job/am-packbuild/job/rpm-jenkinsci/503/

Connects to https://github.com/archivematica/Issues/issues/1179