### PR TITLE
am/rpm: delete font-awesome workaround

### DIFF
--- a/rpm/archivematica/archivematica.spec
+++ b/rpm/archivematica/archivematica.spec
@@ -196,9 +196,6 @@ cp %{_etcdir}/dashboard.nginx %{buildroot}/etc/nginx/conf.d/archivematica-dashbo
 cd %{_sourcedir}/%{name}/src/dashboard/frontend/ && npm install --unsafe-perm
 find %{_sourcedir}/%{name}/src/dashboard/ | grep static
 cp -rf %{_sourcedir}/%{name}/src/dashboard/src/* %{buildroot}/usr/share/archivematica/dashboard/
-# Remove font-awesome's symlink and copy its directory from frontend dir
-rm %{buildroot}/usr/share/archivematica/dashboard/media/vendor/font-awesome
-cp -rf %{_sourcedir}/%{name}/src/dashboard/frontend/node_modules/font-awesome %{buildroot}/usr/share/archivematica/dashboard/media/vendor/font-awesome
 
 #
 # Clean up build directory


### PR DESCRIPTION
Not needed since https://github.com/artefactual/archivematica/pull/1660.

Connects to https://github.com/archivematica/Issues/issues/1300.

This should also be included in stable/1.12.x.