### PR TITLE
Update changelogs and vagrant box for v1.12.1

### DIFF
--- a/debs/bionic/archivematica-storage-service/debian-storage-service/changelog
+++ b/debs/bionic/archivematica-storage-service/debian-storage-service/changelog
@@ -1,3 +1,10 @@
+archivematica-storage-service (1:0.17.1-1~18.04) bionic; urgency=high
+
+  * commit: f02b9149863efe3e883806b7d470ab3c55273d03
+  * checkout: v0.17.1
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Thu, 07 Jan 2021 10:09:51 +0000
+
 archivematica-storage-service (1:0.17.0-1~18.04) bionic; urgency=high
 
   * commit: 6bf42f090b779e436203d24dc76e26f4c051e73d

--- a/debs/bionic/archivematica/debian-MCPClient/changelog
+++ b/debs/bionic/archivematica/debian-MCPClient/changelog
@@ -1,3 +1,10 @@
+archivematica-mcp-client (1:1.12.1-1~18.04) bionic; urgency=high
+
+  * commit: a31f218ceabc5bbe996775b82b9c9861b2f406d9
+  * checkout: v1.12.1
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Thu, 07 Jan 2021 09:59:21 +0000
+
 archivematica-mcp-client (1:1.12.0-1~18.04) bionic; urgency=high
 
   * commit: c5e7a0fb4aaaf5d30d20e46707b66f788d7a0fba

--- a/debs/bionic/archivematica/debian-MCPServer/changelog
+++ b/debs/bionic/archivematica/debian-MCPServer/changelog
@@ -1,3 +1,10 @@
+archivematica-mcp-server (1:1.12.1-1~18.04) bionic; urgency=high
+
+  * commit: a31f218ceabc5bbe996775b82b9c9861b2f406d9
+  * checkout: v1.12.1
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Thu, 07 Jan 2021 10:00:59 +0000
+
 archivematica-mcp-server (1:1.12.0-1~18.04) bionic; urgency=high
 
   * commit: c5e7a0fb4aaaf5d30d20e46707b66f788d7a0fba

--- a/debs/bionic/archivematica/debian-archivematicaCommon/changelog
+++ b/debs/bionic/archivematica/debian-archivematicaCommon/changelog
@@ -1,3 +1,10 @@
+archivematica-common (1:1.12.1-1~18.04) bionic; urgency=high
+
+  * commit: a31f218ceabc5bbe996775b82b9c9861b2f406d9
+  * checkout: v1.12.1
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Thu, 07 Jan 2021 10:02:25 +0000
+
 archivematica-common (1:1.12.0-1~18.04) bionic; urgency=high
 
   * commit: c5e7a0fb4aaaf5d30d20e46707b66f788d7a0fba

--- a/debs/bionic/archivematica/debian-dashboard/changelog
+++ b/debs/bionic/archivematica/debian-dashboard/changelog
@@ -1,3 +1,10 @@
+archivematica-dashboard (1:1.12.1-1~18.04) bionic; urgency=high
+
+  * commit: a31f218ceabc5bbe996775b82b9c9861b2f406d9
+  * checkout: v1.12.1
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Thu, 07 Jan 2021 09:55:33 +0000
+
 archivematica-dashboard (1:1.12.0-1~18.04) bionic; urgency=high
 
   * commit: c5e7a0fb4aaaf5d30d20e46707b66f788d7a0fba

--- a/debs/xenial/archivematica-storage-service/debian-storage-service/changelog
+++ b/debs/xenial/archivematica-storage-service/debian-storage-service/changelog
@@ -1,3 +1,10 @@
+archivematica-storage-service (1:0.17.1-1~16.04) xenial; urgency=high
+
+  * commit: f02b9149863efe3e883806b7d470ab3c55273d03
+  * checkout: v0.17.1
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Thu, 07 Jan 2021 10:09:51 +0000
+
 archivematica-storage-service (1:0.17.0-1~16.04) xenial; urgency=high
 
   * commit: 6bf42f090b779e436203d24dc76e26f4c051e73d

--- a/debs/xenial/archivematica/debian-MCPClient/changelog
+++ b/debs/xenial/archivematica/debian-MCPClient/changelog
@@ -1,3 +1,10 @@
+archivematica-mcp-client (1:1.12.1-1~16.04) xenial; urgency=high
+
+  * commit: a31f218ceabc5bbe996775b82b9c9861b2f406d9
+  * checkout: v1.12.1
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Thu, 07 Jan 2021 10:00:38 +0000
+
 archivematica-mcp-client (1:1.12.0-1~16.04) xenial; urgency=high
 
   * commit: c5e7a0fb4aaaf5d30d20e46707b66f788d7a0fba

--- a/debs/xenial/archivematica/debian-MCPServer/changelog
+++ b/debs/xenial/archivematica/debian-MCPServer/changelog
@@ -1,3 +1,10 @@
+archivematica-mcp-server (1:1.12.1-1~16.04) xenial; urgency=high
+
+  * commit: a31f218ceabc5bbe996775b82b9c9861b2f406d9
+  * checkout: v1.12.1
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Thu, 07 Jan 2021 10:03:46 +0000
+
 archivematica-mcp-server (1:1.12.0-1~16.04) xenial; urgency=high
 
   * commit: c5e7a0fb4aaaf5d30d20e46707b66f788d7a0fba

--- a/debs/xenial/archivematica/debian-archivematicaCommon/changelog
+++ b/debs/xenial/archivematica/debian-archivematicaCommon/changelog
@@ -1,3 +1,10 @@
+archivematica-common (1:1.12.1-1~16.04) xenial; urgency=high
+
+  * commit: a31f218ceabc5bbe996775b82b9c9861b2f406d9
+  * checkout: v1.12.1
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Thu, 07 Jan 2021 10:06:36 +0000
+
 archivematica-common (1:1.12.0-1~16.04) xenial; urgency=high
 
   * commit: c5e7a0fb4aaaf5d30d20e46707b66f788d7a0fba

--- a/debs/xenial/archivematica/debian-dashboard/changelog
+++ b/debs/xenial/archivematica/debian-dashboard/changelog
@@ -1,3 +1,10 @@
+archivematica-dashboard (1:1.12.1-1~16.04) xenial; urgency=high
+
+  * commit: a31f218ceabc5bbe996775b82b9c9861b2f406d9
+  * checkout: v1.12.1
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Thu, 07 Jan 2021 09:55:24 +0000
+
 archivematica-dashboard (1:1.12.0-1~16.04) xenial; urgency=high
 
   * commit: c5e7a0fb4aaaf5d30d20e46707b66f788d7a0fba

--- a/packer/templates/vagrant-box-archivematica/provisioning/singlenode.yml
+++ b/packer/templates/vagrant-box-archivematica/provisioning/singlenode.yml
@@ -4,8 +4,8 @@
   vars:
     # archivematica-src role
     - archivematica_src_install_devtools: "yes"
-    - archivematica_src_am_version: "v1.12.0"
-    - archivematica_src_ss_version: "v0.17.0"
+    - archivematica_src_am_version: "v1.12.1"
+    - archivematica_src_ss_version: "v0.17.1"
     - archivematica_src_ss_gunicorn: "true"
     - archivematica_src_am_dashboard_gunicorn: "true"
     - archivematica_src_am_multi_venvs: "true"

--- a/rpm/archivematica-storage-service/changelog
+++ b/rpm/archivematica-storage-service/changelog
@@ -1,4 +1,7 @@
 %changelog
+* Thu Jan 07 2021 Artefactual <sysadmin@artefactual.com> - 0.17.1-1
+- Packbuild: 89f86ab2b5557b490b41b87e42a12a085c8cc186
+- Storage Service: f02b9149863efe3e883806b7d470ab3c55273d03
 * Tue Oct 06 2020 Artefactual <sysadmin@artefactual.com> - 0.17.0-1
 - Packbuild: b55d0f63b1b369e4c5a71be13d7deeb6bb9ea7b9
 - Storage Service: 6bf42f090b779e436203d24dc76e26f4c051e73d

--- a/rpm/archivematica/changelog
+++ b/rpm/archivematica/changelog
@@ -1,4 +1,7 @@
 %changelog
+* Thu Jan 07 2021 Artefactual <sysadmin@artefactual.com> - 1.12.1-1
+- Packbuild: 89f86ab2b5557b490b41b87e42a12a085c8cc186
+- Archivematica: a31f218ceabc5bbe996775b82b9c9861b2f406d9
 * Tue Oct 06 2020 Artefactual <sysadmin@artefactual.com> - 1.12.0-1
 - Packbuild: b55d0f63b1b369e4c5a71be13d7deeb6bb9ea7b9
 - Archivematica: c5e7a0fb4aaaf5d30d20e46707b66f788d7a0fba


### PR DESCRIPTION
- Update AM vagrant box version
- Update packages changelogs (v1.12.1 and v0.17.1)

Connects to https://github.com/archivematica/Issues/issues/1319.