### PR TITLE
Install gettext to compile messages

### DIFF
--- a/debs/bionic/archivematica-storage-service/debian-storage-service/control
+++ b/debs/bionic/archivematica-storage-service/debian-storage-service/control
@@ -22,7 +22,7 @@ X-Python-Version: 2.7
 
 Package: archivematica-storage-service
 Architecture: i386 amd64
-Depends: ${python:Depends}, ${misc:Depends}, nginx, unar (>= 1.8.1-4~), python (>= 2.7.3), rng-tools, gnupg1
+Depends: ${python:Depends}, ${misc:Depends}, nginx, unar (>= 1.8.1-4~), python (>= 2.7.3), rng-tools, gnupg1, gettext
 Description: Django webapp for managing storage in an Archivematica
     installation.
 Homepage: http://archivematica.org

--- a/debs/bionic/archivematica/debian-dashboard/control
+++ b/debs/bionic/archivematica/debian-dashboard/control
@@ -23,7 +23,8 @@ Depends:
 	libssl-dev,
 	python-dev,
 	libxml2-dev,
-	libxslt1-dev
+	libxslt1-dev,
+	gettext
 Description: Web Dashboard for Archivematica
   Web based dashboard interface used to control an Archivematica pipeline.
 

--- a/debs/xenial/archivematica-storage-service/debian-storage-service/control
+++ b/debs/xenial/archivematica-storage-service/debian-storage-service/control
@@ -22,7 +22,7 @@ X-Python-Version: 2.7
 
 Package: archivematica-storage-service
 Architecture: i386 amd64
-Depends: ${python:Depends}, ${misc:Depends}, nginx, unar (>= 1.8.1-4~), python (>= 2.7.3), rng-tools
+Depends: ${python:Depends}, ${misc:Depends}, nginx, unar (>= 1.8.1-4~), python (>= 2.7.3), rng-tools, gettext
 Description: Django webapp for managing storage in an Archivematica
     installation.
 Homepage: http://archivematica.org

--- a/debs/xenial/archivematica/debian-dashboard/control
+++ b/debs/xenial/archivematica/debian-dashboard/control
@@ -24,7 +24,8 @@ Depends:
 	libssl-dev,
 	python-dev,
 	libxml2-dev,
-	libxslt1-dev
+	libxslt1-dev,
+	gettext
 Description: Web Dashboard for Archivematica
   Web based dashboard interface used to control an Archivematica pipeline.
 

--- a/rpm/archivematica-storage-service/package.spec
+++ b/rpm/archivematica-storage-service/package.spec
@@ -9,7 +9,7 @@ Group: Application/System
 License: AGPLv3
 Source0: %{git_repo}
 BuildRequires: git, gcc, libffi-devel, openssl-devel, libxslt-devel, python-virtualenv, python-pip, mariadb-devel, postgresql-devel, gcc-c++, openldap-devel
-Requires: gnupg, libxslt-devel, policycoreutils-python, rng-tools, rsync, nginx, unar, p7zip, shadow-utils
+Requires: gnupg, libxslt-devel, policycoreutils-python, rng-tools, rsync, nginx, unar, p7zip, shadow-utils, gettext
 AutoReq: No
 AutoProv: No
 %description

--- a/rpm/archivematica/archivematica.spec
+++ b/rpm/archivematica/archivematica.spec
@@ -81,7 +81,7 @@ Archivematica MCP client.
 
 %package dashboard
 Summary: Archivematica dashboard
-Requires: archivematica, nginx, policycoreutils-python
+Requires: archivematica, nginx, policycoreutils-python, gettext
 AutoReq: No
 AutoProv: No
 %description dashboard


### PR DESCRIPTION
On my CentOS testing environment, gettext came installed. The same did not happen in Xenial or Bionic. This pull request adds the dependency where used, regardless whether it comes pre-installed (i.e. explicit better than implicit). gettext is needed by the Django framework when running the `compilemessages` task, which is something we do in archivematica-dashboard and archivematica-storage-service.

Depends on https://github.com/artefactual-labs/am-packbuild/pull/295.
Connects to https://github.com/archivematica/Issues/issues/984.