### PR TITLE
Add GA workflow to update AtoM's Vagrant box

### DIFF
--- a/.github/workflows/vagrant-box-atom.yml
+++ b/.github/workflows/vagrant-box-atom.yml
@@ -1,0 +1,36 @@
+name: AtoM Vagrant box
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version
+        required: true
+      description:
+        description: Description
+        required: true
+jobs: 
+  vagrant-box-atom:
+    name: Build and upload
+    runs-on: macos-10.15
+    env:
+      PACKER_CACHE_DIR: ${{ github.workspace }}/.packer_cache
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+    - name: Build
+      run: |
+        cd ${{ github.workspace }}/packer/templates/vagrant-base-ubuntu-20.04-amd64
+        packer build -on-error=abort template.json
+        cd ${{ github.workspace }}/packer/templates/vagrant-box-atom
+        packer build -on-error=abort template.json
+        mv ${{ github.workspace }}/packer/builds/virtualbox/vagrant-atom.box \
+          ${{ github.workspace }}/atom-vagrant-${{ github.event.inputs.version }}.box
+    - name: Upload
+      run: |
+        cd ${{ github.workspace }}/tools/vagrant-box-atom
+        bundle install
+        ruby upload.rb \
+          '${{ github.workspace }}/atom-vagrant-${{ github.event.inputs.version }}.box' \
+          '${{ secrets.VAGRANT_CLOUD }}' \
+          '${{ github.event.inputs.version }}' \
+          '${{ github.event.inputs.description }}'

--- a/tools/vagrant-box-atom/Gemfile
+++ b/tools/vagrant-box-atom/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'vagrant_cloud', '3.0.4'

--- a/tools/vagrant-box-atom/Gemfile.lock
+++ b/tools/vagrant-box-atom/Gemfile.lock
@@ -1,0 +1,18 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    excon (0.80.1)
+    log4r (1.1.10)
+    vagrant_cloud (3.0.4)
+      excon (~> 0.73)
+      log4r (~> 1.1.10)
+
+PLATFORMS
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+  vagrant_cloud (= 3.0.4)
+
+BUNDLED WITH
+   2.2.16

--- a/tools/vagrant-box-atom/README.md
+++ b/tools/vagrant-box-atom/README.md
@@ -1,0 +1,18 @@
+# AtoM Vagrant box upload
+
+Ruby script to release a new AtoM Vagrant box version in Vagrant Cloud.
+
+## Requirements
+
+[Ruby](https://www.ruby-lang.org/) and [Bundler](https://bundler.io/).
+
+## Usage
+
+```
+bundle install
+ruby upload.rb \
+  /path/to/atom-vagrant-2.7.0.2.box \
+  vagrant_cloud_secret \
+  2.7.0.2 \
+  'AtoM qa/2.x on Ubuntu 20.04.<br/><br/>Add PHP PCOV extension.'
+```

--- a/tools/vagrant-box-atom/upload.rb
+++ b/tools/vagrant-box-atom/upload.rb
@@ -1,0 +1,59 @@
+#!/usr/bin/env ruby
+
+require 'bundler/setup'
+require 'net/http'
+require 'vagrant_cloud'
+
+ORG = 'artefactual'
+BOX = 'atom'
+PROVIDER = 'virtualbox'
+
+path = ARGV[0]
+token = ARGV[1]
+version = ARGV[2]
+description = ARGV[3]
+
+client = VagrantCloud::Client.new(access_token: token)
+
+client.box_version_create(
+    username: ORG,
+    name: BOX,
+    version: version,
+    description: description
+)
+
+client.box_version_provider_create(
+    username: ORG,
+    name: BOX,
+    version: version,
+    provider: PROVIDER
+)
+
+upload_url = client.box_version_provider_upload(
+    username: ORG,
+    name: BOX,
+    version: version,
+    provider: PROVIDER
+)
+
+uri = URI.parse(upload_url[:upload_path])
+request = Net::HTTP::Put.new(uri)
+box = File.open(path, 'rb')
+request.set_form([['file', box]], 'multipart/form-data')
+response = Net::HTTP.start(
+    uri.hostname,
+    uri.port,
+    use_ssl: uri.scheme.eql?('https')
+) do |http|
+    http.request(request)
+end
+
+if response.is_a?(Net::HTTPSuccess)
+    client.box_version_release(
+        username: ORG,
+        name: BOX,
+        version: version,
+    )
+else
+    abort('ABORTED! Vagrant box could not be uploaded.')
+end


### PR DESCRIPTION
Add a manually triggered Github actions workflow, accepting `version`
and `description` as inputs, to build and upload AtoM's Vagrant box. Use
a Ruby script to upload the box with Hashicorp's Ruby client for the
Vagrant Cloud API.

Refs https://trello.com/c/vMINa4M8/323-atom-vagrant-box-automated-build-and-upload.