### PR TITLE
packer: Add new focal template for APH+ servers

### DIFF
--- a/packer/http/ubuntu-20.04/preseed-nolvm.cfg
+++ b/packer/http/ubuntu-20.04/preseed-nolvm.cfg
@@ -1,0 +1,42 @@
+choose-mirror-bin mirror/http/proxy string
+d-i base-installer/kernel/override-image string linux-server
+d-i clock-setup/utc boolean true
+d-i clock-setup/utc-auto boolean true
+d-i finish-install/reboot_in_progress note
+d-i grub-installer/only_debian boolean true
+d-i grub-installer/with_other_os boolean true
+
+d-i partman-auto/disk string /dev/sda
+d-i partman-auto/method string regular
+d-i partman-basicfilesystems/no_swap boolean false
+d-i partman-auto/expert_recipe string myroot :: 1000 50 -1 ext4 \
+     $primary{ } $bootable{ } method{ format } \
+     format{ } use_filesystem{ } filesystem{ ext4 } \
+     mountpoint{ / } \
+    .
+d-i partman-auto/choose_recipe select myroot
+d-i partman-partitioning/confirm_write_new_label boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+d-i pkgsel/include string openssh-server cryptsetup build-essential libssl-dev libreadline-dev zlib1g-dev linux-source dkms nfs-common xfsprogs
+d-i pkgsel/install-language-support boolean false
+d-i pkgsel/update-policy select none
+d-i pkgsel/upgrade select full-upgrade
+d-i time/zone string UTC
+tasksel tasksel/first multiselect standard, ubuntu-server
+
+d-i console-setup/ask_detect boolean false
+d-i keyboard-configuration/layoutcode string us
+d-i keyboard-configuration/modelcode string pc105
+d-i debian-installer/locale string en_US.UTF-8
+
+# Create vagrant user account.
+d-i passwd/user-fullname string vagrant
+d-i passwd/username string vagrant
+d-i passwd/user-password password vagrant
+d-i passwd/user-password-again password vagrant
+d-i user-setup/allow-password-weak boolean true
+d-i user-setup/encrypt-home boolean false
+d-i passwd/user-default-groups vagrant sudo
+d-i passwd/user-uid string 900

--- a/packer/scripts/ubuntu/cloud-init.sh
+++ b/packer/scripts/ubuntu/cloud-init.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -eux
+
+apt-get install -y cloud-init cloud-utils

--- a/packer/templates/vagrant-base-ubuntu-20.04-amd64-aph/template.json
+++ b/packer/templates/vagrant-base-ubuntu-20.04-amd64-aph/template.json
@@ -1,0 +1,108 @@
+{
+  "builders": [
+    {
+      "boot_command": [
+        "<enter><wait><f6><esc><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "/install/vmlinuz<wait>",
+        " auto<wait>",
+        " console-setup/ask_detect=false<wait>",
+        " console-setup/layoutcode=us<wait>",
+        " console-setup/modelcode=pc105<wait>",
+        " debconf/frontend=noninteractive<wait>",
+        " debian-installer=en_US.UTF-8<wait>",
+        " fb=false<wait>",
+        " initrd=/install/initrd.gz<wait>",
+        " kbd-chooser/method=us<wait>",
+        " keyboard-configuration/layout=USA<wait>",
+        " keyboard-configuration/variant=USA<wait>",
+        " locale=en_US.UTF-8<wait>",
+        " netcfg/get_domain=vm<wait>",
+        " netcfg/get_hostname=vagrant<wait>",
+        " grub-installer/bootdev=/dev/sda<wait>",
+        " noapic<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed-nolvm.cfg<wait>",
+        " -- <wait>",
+        "<enter><wait>"
+      ],
+      "boot_wait": "10s",
+      "disk_size": "{{user `disk_size`}}",
+      "guest_os_type": "Ubuntu_64",
+      "hard_drive_interface": "sata",
+      "headless": "{{ user `headless` }}",
+      "http_directory": "../../http/ubuntu-20.04",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_urls": [
+        "iso/ubuntu-20.04.1-legacy-server-amd64.iso",
+        "http://cdimage.ubuntu.com/ubuntu-legacy-server/releases/20.04.1/release/ubuntu-20.04.1-legacy-server-amd64.iso"
+       ],
+      "output_directory": "../../builds/virtualbox/vagrant-base-ubuntu-20.04-amd64-aph",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
+      "type": "virtualbox-iso",
+      "vboxmanage": [
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "{{ user `memory` }}"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "{{ user `cpus` }}"
+        ]
+      ],
+      "virtualbox_version_file": ".vbox_version",
+      "vm_name": "{{ user `template` }}"
+    }
+  ],
+  "provisioners": [
+     {
+      "environment_vars": [
+        "HOME_DIR=/home/vagrant",
+        "http_proxy={{user `http_proxy`}}",
+        "https_proxy={{user `https_proxy`}}",
+        "no_proxy={{user `no_proxy`}}"
+      ],
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true,
+      "scripts": [
+        "../../scripts/ubuntu/update.sh",
+        "../../scripts/ubuntu/cloud-init.sh",
+        "../../scripts/common/sshd.sh",
+        "../../scripts/ubuntu/networking.sh",
+        "../../scripts/ubuntu/cleanup.sh",
+        "../../scripts/common/minimize.sh"
+      ],
+      "type": "shell"
+    }
+  ],
+  "variables": {
+    "box_basename": "ubuntu-20.04-aph",
+    "build_timestamp": "{{isotime}}",
+    "cpus": "4",
+    "disk_size": "5000",
+    "git_revision": "__unknown_git_revision__",
+    "headless": "true",
+    "http_proxy": "{{env `http_proxy`}}",
+    "https_proxy": "{{env `https_proxy`}}",
+    "iso_checksum": "f11bda2f2caed8f420802b59f382c25160b114ccc665dbac9c5046e7fceaced2",
+    "iso_name": "ubuntu-20.04.1-legacy-server-amd64.iso",
+    "memory": "8192",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://cdimage.ubuntu.com/ubuntu-legacy-server/releases",
+    "mirror_directory": "20.04.1/release/",
+    "name": "ubuntu-20.04",
+    "no_proxy": "{{env `no_proxy`}}",
+    "preseed_path": "../../http/ubuntu-20.04/preseed-nolvm.cfg",
+    "template": "vagrant-base-ubuntu-20.04-amd64-aph",
+    "version": "2.1.TIMESTAMP"
+  }
+}


### PR DESCRIPTION
Adds a new template to be used with APH AtoM servers (Ubuntu focal). 

Differences with the existing focal template:

* Cloud-init support
* Don't use LVM for partitions
