### PR TITLE
Remove pyc files from postinst

### DIFF
--- a/debs/bionic/archivematica-storage-service/debian-storage-service/postinst
+++ b/debs/bionic/archivematica-storage-service/debian-storage-service/postinst
@@ -28,11 +28,10 @@ echo "creating symlink in /usr/lib/archivematica"
 rm -f /usr/lib/archivematica/storage-service
 ln -s -f ${SS_ENV_DIR}/lib/python3.6/site-packages/storage_service/ /usr/lib/archivematica/storage-service
 
-cd /usr/lib/archivematica/storage-service
-
-echo "configuring django database and static files"
 find /usr/lib/archivematica/storage-service/ -name '*.pyc' -delete
 
+echo "configuring django database and static files"
+cd /usr/lib/archivematica/storage-service
 ${SS_ENV_DIR}/bin/python manage.py migrate
 mkdir -p /usr/lib/archivematica/storage-service/assets
 ${SS_ENV_DIR}/bin/python manage.py collectstatic --noinput --clear

--- a/debs/bionic/archivematica/debian-MCPClient/postinst
+++ b/debs/bionic/archivematica/debian-MCPClient/postinst
@@ -19,5 +19,7 @@ sed -i "s/^\(ARCHIVEMATICA_MCPCLIENT_CLIENT_DATABASE=\).*/\1$DBNAME/g" /etc/defa
 ucfr archivematica-mcp-client /etc/default/archivematica-mcp-client
 ucf --debconf-ok /etc/default/archivematica-mcp-client /etc/default/archivematica-mcp-client
 
+find /usr/lib/archivematica/MCPClient/ -name '*.pyc' -delete
+
 #DEBHELPER#
 

--- a/debs/bionic/archivematica/debian-MCPServer/postinst
+++ b/debs/bionic/archivematica/debian-MCPServer/postinst
@@ -32,5 +32,7 @@ sed -i "s/^\(ARCHIVEMATICA_MCPSERVER_CLIENT_DATABASE=\).*/\1$DBNAME/g" /etc/defa
 ucfr archivematica-mcp-server /etc/default/archivematica-mcp-server
 ucf --debconf-ok /etc/default/archivematica-mcp-server /etc/default/archivematica-mcp-server
 
+find /usr/lib/archivematica/MCPServer/ -name '*.pyc' -delete
+
 #DEBHELPER#
 

--- a/debs/bionic/archivematica/debian-archivematicaCommon/postinst
+++ b/debs/bionic/archivematica/debian-archivematicaCommon/postinst
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+find /usr/lib/archivematica/archivematicaCommon/ -name '*.pyc' -delete

--- a/debs/bionic/archivematica/debian-dashboard/postinst
+++ b/debs/bionic/archivematica/debian-dashboard/postinst
@@ -33,6 +33,8 @@ sed -i "s/^\(ARCHIVEMATICA_DASHBOARD_CLIENT_DATABASE=\).*/\1$DBNAME/g" /etc/defa
 ucfr archivematica-dashboard /etc/default/archivematica-dashboard
 ucf --debconf-ok /etc/default/archivematica-dashboard /etc/default/archivematica-dashboard
 
+find /usr/share/archivematica/dashboard/ -name '*.pyc' -delete
+
 #this is required to allow syncdb to work properly
 set -a
 source /etc/default/archivematica-dashboard


### PR DESCRIPTION
This commit ensures that cached bytecode is removed during software upgrades.

Testing from 1.12.0, migrations were applied successfully during the installation.

```
Setting up archivematica-dashboard (1:1.13.1-beta1~18.04) ...
/usr/share/archivematica/dashboard /
Operations to perform:
  Apply all migrations: administration, auth, contenttypes, fpr, main, sessions, tastypie
Running migrations:
  Applying fpr.0034_delete_unused_models... OK
  Applying fpr.0035_python3_compatibility... OK
  Applying main.0079_version_number... OK
  Applying main.0080_delete_software_agent... OK
  Applying main.0081_package_status... OK
```

Connects to https://github.com/archivematica/Issues/issues/1503.