### PR TITLE
Tweak SS unit to be restarted automatically

### DIFF
--- a/debs/bionic/archivematica-storage-service/debian-storage-service/archivematica-storage-service.service
+++ b/debs/bionic/archivematica-storage-service/debian-storage-service/archivematica-storage-service.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Archivematica Storage Service
-After=network.target
+After=network.target mysql.service
+StartLimitInterval=200
+StartLimitBurst=5
 
 [Service]
 PIDFile=/run/archivematica-storage-service_gunicorn.pid
@@ -12,6 +14,8 @@ ExecStart=/usr/share/archivematica/virtualenvs/archivematica-storage-service/bin
 ExecReload=/bin/kill -s HUP $MAINPID
 ExecStop=/bin/kill -s TERM $MAINPID
 PrivateTmp=true      
+Restart=always
+RestartSec=30
 
 [Install]
 WantedBy=multi-user.target

--- a/rpm/archivematica-storage-service/etc/archivematica-storage-service.service
+++ b/rpm/archivematica-storage-service/etc/archivematica-storage-service.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Archivematica Storage Service
-After=network.target
+After=network.target mariadb.service
+StartLimitInterval=200
+StartLimitBurst=5
 
 [Service]
 PIDFile=/run/archivematica-storage-service_gunicorn.pid
@@ -12,6 +14,8 @@ ExecStart=/usr/share/archivematica/virtualenvs/archivematica-storage-service/bin
 ExecReload=/bin/kill -s HUP $MAINPID
 ExecStop=/bin/kill -s TERM $MAINPID
 PrivateTmp=true
+Restart=always
+RestartSec=30
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Also, configure service order where possible. [`After`](https://serverfault.com/a/812589) does not state a dependency so it's safe to use when MySQL isn't installed.

Connects to https://github.com/archivematica/Issues/issues/1480.