### PR TITLE
Update vagrant-box-archivematica (v1.13.1)

### DIFF
--- a/packer/templates/vagrant-base-ubuntu-18.04-amd64/template.json
+++ b/packer/templates/vagrant-base-ubuntu-18.04-amd64/template.json
@@ -35,8 +35,8 @@
       "http_directory": "../../http/ubuntu-18.04",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_urls": [
-        "iso/ubuntu-18.04.5-server-amd64.iso",
-        "http://cdimage.ubuntu.com/releases/18.04.5/release/ubuntu-18.04.5-server-amd64.iso"
+        "iso/ubuntu-18.04.6-server-amd64.iso",
+        "http://cdimage.ubuntu.com/releases/18.04.6/release/ubuntu-18.04.6-server-amd64.iso"
        ],
       "output_directory": "../../builds/virtualbox/vagrant-base-ubuntu-18.04-amd64",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
@@ -95,12 +95,12 @@
     "headless": "true",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
-    "iso_checksum": "8c5fc24894394035402f66f3824beb7234b757dd2b5531379cb310cedfdf0996",
-    "iso_name": "ubuntu-18.04.5-server-amd64.iso",
+    "iso_checksum": "f5cbb8104348f0097a8e513b10173a07dbc6684595e331cb06f93f385d0aecf6",
+    "iso_name": "ubuntu-18.04.6-server-amd64.iso",
     "memory": "4096",
     "metadata": "floppy/dummy_metadata.json",
     "mirror": "http://cdimage.ubuntu.com/releases",
-    "mirror_directory": "18.04.5/",
+    "mirror_directory": "18.04.6/",
     "name": "ubuntu-18.04",
     "no_proxy": "{{env `no_proxy`}}",
     "preseed_path": "../../http/ubuntu-18.04/preseed.cfg",

--- a/packer/templates/vagrant-box-archivematica/provisioning/group_vars/servers
+++ b/packer/templates/vagrant-box-archivematica/provisioning/group_vars/servers
@@ -2,8 +2,8 @@
 
 # archivematica-src role
 
-archivematica_src_am_version: "v1.13.0-rc.4"
-archivematica_src_ss_version: "v0.18.0-rc.4"
+archivematica_src_am_version: "v1.13.1"
+archivematica_src_ss_version: "v0.18.1"
 
 archivematica_src_ss_db_name: "SS"
 archivematica_src_ss_db_user: "ss"


### PR DESCRIPTION
Here's the [build](https://github.com/artefactual-labs/am-packbuild/runs/3941128706) that publishes the [1.13.1 box](https://app.vagrantup.com/artefactual/boxes/archivematica/versions/1.13.1) (still running but should be done soon, unless it fails...).