### PR TITLE
 Update changelogs after SS 0.19.0 release 

### DIFF
--- a/debs/bionic/archivematica-storage-service/Makefile
+++ b/debs/bionic/archivematica-storage-service/Makefile
@@ -5,7 +5,7 @@ DOCKER_VOLUME = "/src"
 DOCKER_IMAGE  = "debbuild-$(NAME)-$(PACKAGE)-$(VERSION)"
 GPG_ID        ?= 0F4A4D31
 BRANCH        ?= qa/0.x
-VERSION       ?= 0.18.0
+VERSION       ?= 0.19.0
 RELEASE       ?= -1
 GIT_REPO      = "https://github.com/artefactual/archivematica-storage-service"
 
@@ -27,7 +27,7 @@ build: build-docker-image
 		-e GPG_ID=$(GPG_ID) \
 		-e GPG_KEY \
 		-e GIT_REPO="$(GIT_REPO)" \
- 		--rm \
+		--rm \
 		--volume "$(shell cd ../../ && pwd):$(DEB_TOPDIR)/$(NAME)" \
 		--volume "$(shell pwd):$(DOCKER_VOLUME)" \
 		$(DOCKER_IMAGE) \

--- a/debs/bionic/archivematica-storage-service/debian-storage-service/changelog
+++ b/debs/bionic/archivematica-storage-service/debian-storage-service/changelog
@@ -1,3 +1,10 @@
+archivematica-storage-service (1:0.19.0-1~18.04) bionic; urgency=high
+
+  * commit: ab64d17f8220428091699870f6a14ac8dc45136b
+  * checkout: v0.19.0
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Tue, 01 Mar 2022 18:08:06 +0000
+
 archivematica-storage-service (1:0.18.1-1~18.04) bionic; urgency=high
 
   * commit: 0fb9d0a89524d6485e7f2fbce2ed868ebdf38f45

--- a/rpm/archivematica-storage-service/Makefile
+++ b/rpm/archivematica-storage-service/Makefile
@@ -1,6 +1,6 @@
 NAME          = archivematica-storage-service
 BRANCH        ?= qa/0.x
-VERSION       ?= 0.18.0
+VERSION       ?= 0.19.0
 RELEASE       ?= 1
 RPM_TOPDIR    = "/rpmbuild"
 DOCKER_VOLUME = "/src"

--- a/rpm/archivematica-storage-service/changelog
+++ b/rpm/archivematica-storage-service/changelog
@@ -1,4 +1,7 @@
 %changelog
+* Fri Feb 25 2022 Artefactual <sysadmin@artefactual.com> - 0.19.0-1
+- Packbuild: 4fc45c4652a5f0f706d04cfc5eb43463c985517e
+- Storage Service: ab64d17f8220428091699870f6a14ac8dc45136b
 * Tue Oct 19 2021 Artefactual <sysadmin@artefactual.com> - 0.18.1-1
 - Packbuild: af5513e91169e5ccc32173e6e490acdc15960df3
 - Storage Service: 0fb9d0a89524d6485e7f2fbce2ed868ebdf38f45


### PR DESCRIPTION
- Update SS version in Makefiles

SS 0.19.0 packages:

Bionic SS: https://jenkins-ci.archivematica.org/job/am-packbuild/job/bionic-jenkinsci/564/
CentOS SS: Built manually in the jenkins-ci server when Jenkins was down

Connected to https://github.com/archivematica/Issues/issues/1522