### PR TITLE
Siegfried: Update to v1.9.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ target/
 # deb build artifacts
 debs/*/*/repo
 debs/*/*/src
+debs/*/src

--- a/debs/siegfried/Dockerfile
+++ b/debs/siegfried/Dockerfile
@@ -1,9 +1,10 @@
 FROM ubuntu:xenial
 
 # Environmnet variables needed during build
-ENV GOVERSION 1.13
+ENV GOVERSION 1.19
 ENV GOOS linux
 ENV GOARCH amd64
+ARG DEBIAN_FRONTEND=noninteractive
 
 # Environment variables needed during runtime
 ENV GOPATH /go
@@ -15,9 +16,6 @@ RUN apt-get update && \
     curl -sO https://storage.googleapis.com/golang/go${GOVERSION}.${GOOS}-${GOARCH}.tar.gz && \
     tar -C /usr/local -xzf go${GOVERSION}.${GOOS}-${GOARCH}.tar.gz && \
     rm go${GOVERSION}.${GOOS}-${GOARCH}.tar.gz
-
-# dh-golang doesn't support parameters, and we need to run it with -tags archivematica
-ADD files/golang.pm /usr/share/perl5/Debian/Debhelper/Buildsystem/golang.pm
 
 # Install build dependencies
 

--- a/debs/siegfried/Makefile
+++ b/debs/siegfried/Makefile
@@ -1,13 +1,14 @@
 NAME          = siegfried
 PACKAGE       = siegfried
-VERSION       ?= 1.8.0
+VERSION       ?= 1.9.6
 RELEASE       ?= 1
-BRANCH        ?= v1.8.0
+BRANCH        ?= v1.9.6
 GIT_URL       = https://github.com/richardlehane/siegfried/
 DEB_TOPDIR    = "/debbuild"
 DOCKER_VOLUME = "/src"
 DOCKER_IMAGE  = "debbuild-$(NAME)-$(VERSION)"
 GPG_ID        ?= 0F4A4D31
+DISTRO_CODENAME = xenial
 .PHONY: build-docker-image build deb-build deb-clean deb-test
 
 all: build-docker-image get-code build
@@ -37,7 +38,7 @@ deb-build:
 	@cp debian src/$(PACKAGE) -rf
 	@cd src/$(PACKAGE) && \
 	dch -v ${VERSION}-${RELEASE} Commit $(shell cat src/$(PACKAGE)/.git/HEAD) && \
-	dch -r --distribution trusty --urgency medium ignored && \
+	dch -r --distribution $(DISTRO_CODENAME) --urgency medium ignored && \
 	yes | mk-build-deps --install debian/control
 	@echo "==> Build package."
 	cd src/$(PACKAGE) && PATH=${PATH} GOPATH=${GOPATH} dpkg-buildpackage -k${GPG_ID}
@@ -57,4 +58,4 @@ get-code:
 		src/$(PACKAGE)
 
 deb-test:
-	@docker run --rm --volume="$(shell pwd):$(DOCKER_VOLUME)" ubuntu:trusty echo "Create repo and install package"
+	@docker run --rm --volume="$(shell pwd):$(DOCKER_VOLUME)" ubuntu:$(DISTRO_CODENAME) echo "Create repo and install package"

--- a/debs/siegfried/debian/changelog
+++ b/debs/siegfried/debian/changelog
@@ -1,3 +1,15 @@
+siegfried (1.9.6-1) xenial; urgency=medium
+
+  * Build version v1.9.6-1, with custom archivematica configuration
+  * Use DH_GOPKG=github.com/richardlehane/siegfried/cmd
+  * Use GOFLAGS="-buildvcs=false -tags=archivematica"
+  * Use GOCACHE=/tmp/go-builds
+  * Remove custom /usr/share/perl5/Debian/Debhelper/Buildsystem/golang.pm.
+    The tags=archivematica is defined on GOFLAGS.
+  * Use Go 1.19
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Wed, 22 Jan 2023 09:04:00 +0000
+
 siegfried (1.8.0-1) trusty; urgency=medium
 
   * Build version v1.8.0-1, with custom archivematica configuration

--- a/debs/siegfried/debian/rules
+++ b/debs/siegfried/debian/rules
@@ -2,7 +2,9 @@
 
 export DH_OPTIONS
 
+export GOFLAGS := -buildvcs=false -tags=archivematica
 export DH_GOPKG := github.com/richardlehane/siegfried/cmd
+export GOCACHE := /tmp/go-builds
 
 #export GOROOT := $(CURDIR)/$(BUILD_DIR)/go
 # Tests assume a fixed position for the PRONOM files,

--- a/rpm/siegfried/Dockerfile
+++ b/rpm/siegfried/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:7
 
 # Environmnet variables needed during build
-ENV GOVERSION 1.13
+ENV GOVERSION 1.19
 ENV GOOS linux
 ENV GOARCH amd64
 

--- a/rpm/siegfried/Makefile
+++ b/rpm/siegfried/Makefile
@@ -1,5 +1,5 @@
 NAME          = siegfried
-VERSION       = 1.8.0
+VERSION       = 1.9.6
 RPM_TOPDIR    = "/rpmbuild"
 DOCKER_VOLUME = "/src"
 DOCKER_IMAGE  = "rpmbuild-$(NAME)-$(VERSION)"
@@ -29,7 +29,8 @@ rpm-build: rpm-clean
 	cd $(SIEGFRIED_SRC)
 
 	@echo "==> Building sources."
-	go install -tags archivematica -v github.com/richardlehane/siegfried/cmd/...
+	go install -tags archivematica -v github.com/richardlehane/siegfried/cmd/sf@v$(VERSION)
+	go install -tags archivematica -v github.com/richardlehane/siegfried/cmd/roy@v$(VERSION)
 
 	@echo "==> Preparing environment for rpmbuild."
 	mkdir -p $(RPM_TOPDIR)/{BUILD,RPMS,SRPMS}

--- a/rpm/siegfried/package.spec
+++ b/rpm/siegfried/package.spec
@@ -28,3 +28,7 @@ rm -rf $RPM_BUILD_ROOT
 /usr/bin/roy
 /usr/bin/sf
 /usr/share/siegfried
+
+%changelog
+* Wed Mar 22 2023 sysadmin@artefactual.com
+- Update to v1.9.6


### PR DESCRIPTION
Connects to https://github.com/archivematica/Issues/issues/1592

* Update siegfried to v1.9.6
* Use golang 1.19 instead of 1.13
* Update packages changelogs
* Add debs/*/src to .gitignore

RPM specific changes:

* Use go install with "package@version" instead of "cmd/..."

DEB specific changes:

* Use DH_GOPKG=github.com/richardlehane/siegfried/cmd
* Use GOFLAGS="-buildvcs=false -tags=archivematica"
* Use GOCACHE=/tmp/go-builds
* Remove custom /usr/share/perl5/Debian/Debhelper/Buildsystem/golang.pm. The tags=archivematica is defined on GOFLAGS.