### PR TITLE
Update ansible requirements format for the AM box

### DIFF
--- a/packer/templates/vagrant-box-archivematica/requirements.yml
+++ b/packer/templates/vagrant-box-archivematica/requirements.yml
@@ -1,25 +1,25 @@
 ---
+roles:
+  - src: "https://github.com/artefactual-labs/ansible-elasticsearch"
+    version: "master"
+    name: "artefactual.elasticsearch"
 
-- src: "https://github.com/artefactual-labs/ansible-elasticsearch"
-  version: "master"
-  name: "artefactual.elasticsearch"
+  - src: "https://github.com/artefactual-labs/ansible-percona"
+    version: "master"
+    name: "artefactual.percona"
 
-- src: "https://github.com/artefactual-labs/ansible-percona"
-  version: "master"
-  name: "artefactual.percona"
+  - src: "https://github.com/artefactual-labs/ansible-nginx"
+    version: "master"
+    name: "artefactual.nginx"
 
-- src: "https://github.com/artefactual-labs/ansible-nginx"
-  version: "master"
-  name: "artefactual.nginx"
+  - src: "https://github.com/artefactual-labs/ansible-clamav"
+    version: "master"
+    name: "artefactual.clamav"
 
-- src: "https://github.com/artefactual-labs/ansible-clamav"
-  version: "master"
-  name: "artefactual.clamav"
+  - src: "https://github.com/artefactual-labs/ansible-gearman.git"
+    version: "master"
+    name: "artefactual.gearman"
 
-- src: "https://github.com/artefactual-labs/ansible-gearman.git"
-  version: "master"
-  name: "artefactual.gearman"
-
-- src: "https://github.com/artefactual-labs/ansible-archivematica-src"
-  version: "qa/1.x"
-  name: "artefactual.archivematica-src"
+  - src: "https://github.com/artefactual-labs/ansible-archivematica-src"
+    version: "qa/1.x"
+    name: "artefactual.archivematica-src"


### PR DESCRIPTION
It seems the `ansible-local` provisioner in newer versions of `packer` installs ansible roles in a different directory than expected which [makes the build process to fail with](https://github.com/artefactual-labs/am-packbuild/actions/runs/5291698872/jobs/9577589567#step:3:1416):

```
    virtualbox-ovf: - extracting artefactual.elasticsearch to /tmp/packer-provisioner-ansible-local/648c85dc-31f0-5f86-c015-90221dd5b6b8/galaxy_roles/artefactual.elasticsearch
    virtualbox-ovf: - artefactual.elasticsearch (master) was installed successfully
    virtualbox-ovf: - extracting artefactual.percona to /tmp/packer-provisioner-ansible-local/648c85dc-31f0-5f86-c015-90221dd5b6b8/galaxy_roles/artefactual.percona
    virtualbox-ovf: - artefactual.percona (master) was installed successfully
    virtualbox-ovf: - extracting artefactual.nginx to /tmp/packer-provisioner-ansible-local/648c85dc-31f0-5f86-c015-90221dd5b6b8/galaxy_roles/artefactual.nginx
    virtualbox-ovf: - artefactual.nginx (master) was installed successfully
    virtualbox-ovf: - extracting artefactual.clamav to /tmp/packer-provisioner-ansible-local/648c85dc-31f0-5f86-c015-90221dd5b6b8/galaxy_roles/artefactual.clamav
    virtualbox-ovf: - artefactual.clamav (master) was installed successfully
    virtualbox-ovf: - extracting artefactual.gearman to /tmp/packer-provisioner-ansible-local/648c85dc-31f0-5f86-c015-90221dd5b6b8/galaxy_roles/artefactual.gearman
    virtualbox-ovf: - artefactual.gearman (master) was installed successfully
    virtualbox-ovf: - extracting artefactual.archivematica-src to /tmp/packer-provisioner-ansible-local/648c85dc-31f0-5f86-c015-90221dd5b6b8/galaxy_roles/artefactual.archivematica-src
    virtualbox-ovf: - artefactual.archivematica-src (qa/1.x) was installed successfully
    virtualbox-ovf: - adding dependency: geerlingguy.nodejs (6.1.1)
    virtualbox-ovf: - dependency geerlingguy.nodejs already pending installation.
    virtualbox-ovf: - dependency geerlingguy.nodejs already pending installation.
    virtualbox-ovf: - downloading role 'nodejs', owned by geerlingguy
    virtualbox-ovf: - downloading role from https://github.com/geerlingguy/ansible-role-nodejs/archive/6.1.1.tar.gz
    virtualbox-ovf: - extracting geerlingguy.nodejs to /tmp/packer-provisioner-ansible-local/648c85dc-31f0-5f86-c015-90221dd5b6b8/galaxy_roles/geerlingguy.nodejs
    virtualbox-ovf: - geerlingguy.nodejs (6.1.1) was installed successfully
    virtualbox-ovf: Executing Ansible: cd /tmp/packer-provisioner-ansible-local/648c85dc-31f0-5f86-c015-90221dd5b6b8 &&  ANSIBLE_FORCE_COLOR=1 PYTHONUNBUFFERED=1 ansible-playbook /tmp/packer-provisioner-ansible-local/648c85dc-31f0-5f86-c015-90221dd5b6b8/singlenode.yml --extra-vars "packer_build_name=virtualbox-ovf packer_builder_type=virtualbox-ovf packer_http_addr=10.0.2.2:0 -o IdentitiesOnly=yes"  -c local -i /tmp/packer-provisioner-ansible-local/648c85dc-31f0-5f86-c015-90221dd5b6b8/packer-provisioner-ansible-local4235930933
==> virtualbox-ovf: /usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
==> virtualbox-ovf:   from cryptography.exceptions import InvalidSignature
==> virtualbox-ovf: ERROR! the role 'artefactual.elasticsearch' was not found in /tmp/packer-provisioner-ansible-local/648c85dc-31f0-5f86-c015-90221dd5b6b8/roles:/home/vagrant/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles:/tmp/packer-provisioner-ansible-local/648c85dc-31f0-5f86-c015-90221dd5b6b8
==> virtualbox-ovf: 
==> virtualbox-ovf: The error appears to be in '/tmp/packer-provisioner-ansible-local/648c85dc-31f0-5f86-c015-90221dd5b6b8/singlenode.yml': line 16, column 7, but may
==> virtualbox-ovf: be elsewhere in the file depending on the exact syntax problem.
==> virtualbox-ovf: 
==> virtualbox-ovf: The offending line appears to be:
==> virtualbox-ovf: 
==> virtualbox-ovf: 
==> virtualbox-ovf:     - role: "artefactual.elasticsearch"
==> virtualbox-ovf:       ^ here
==> virtualbox-ovf: Error executing Ansible: Non-zero exit status: 1
```

See https://github.com/hashicorp/packer-plugin-ansible/issues/111

A [solution](https://github.com/hashicorp/packer-plugin-ansible/issues/111#issuecomment-1368926943) of that issue is to update the [format of the ansible requirements file](https://docs.ansible.com/ansible/latest/collections_guide/collections_installing.html#install-multiple-collections-with-a-requirements-file).