### PR TITLE
Upgrade Node JS version

### DIFF
--- a/debs/jammy/archivematica/Dockerfile
+++ b/debs/jammy/archivematica/Dockerfile
@@ -21,5 +21,5 @@ RUN apt-get update \
 		pkg-config \
         python3-dev \
 		software-properties-common \
-	&& curl -sL https://deb.nodesource.com/setup_14.x | bash - && apt-get install -y nodejs \
+	&& curl -sL https://deb.nodesource.com/setup_20.x | bash - && apt-get install -y nodejs \
 	&& rm -rf /var/lib/apt/lists/*

--- a/rpm-EL9/archivematica/Dockerfile
+++ b/rpm-EL9/archivematica/Dockerfile
@@ -22,7 +22,7 @@ ENV LC_ALL en_US.UTF-8
 
 # Install node repo and build depends, to speed up the build process
 RUN set -ex \
-    && rpm -Uvh https://rpm.nodesource.com/pub_14.x/el/9/x86_64/nodesource-release-el9-1.noarch.rpm
+    && rpm -Uvh https://rpm.nodesource.com/pub_20.x/el/9/x86_64/nodesource-release-el9-1.noarch.rpm
 
 RUN set -ex \
     && yum -y update \


### PR DESCRIPTION
This upgrades Node JS to match https://github.com/artefactual/archivematica/pull/1875 where the frontend apps rely on `npm` > 9.