### PR TITLE
Downgrade VirtualBox in package build CI workflows

### DIFF
--- a/.github/workflows/test-am-debs.yml
+++ b/.github/workflows/test-am-debs.yml
@@ -96,6 +96,11 @@ jobs:
         wget -O- https://www.virtualbox.org/download/oracle_vbox_2016.asc | sudo gpg --yes --output /usr/share/keyrings/oracle-virtualbox-2016.gpg --dearmor
         echo "deb [arch=amd64 signed-by=/usr/share/keyrings/oracle-virtualbox-2016.gpg] https://download.virtualbox.org/virtualbox/debian jammy contrib" | sudo tee /etc/apt/sources.list.d/virtualbox.list
         sudo apt update && sudo apt install virtualbox-7.0
+    - name: "Downgrade VirtualBox"
+      run: |
+        sudo apt-get purge virtualbox-7.0
+        wget -O /tmp/virtualbox-7.0_7.0.14-161095~Ubuntu~jammy_amd64.deb -L https://download.virtualbox.org/virtualbox/7.0.14/virtualbox-7.0_7.0.14-161095~Ubuntu~jammy_amd64.deb
+        sudo dpkg -i /tmp/virtualbox-7.0_7.0.14-161095~Ubuntu~jammy_amd64.deb
     - name: Install the vagrant-vbguest plugin
       run: |
         vagrant plugin install vagrant-vbguest

--- a/.github/workflows/test-am-rpms.yml
+++ b/.github/workflows/test-am-rpms.yml
@@ -96,6 +96,11 @@ jobs:
         wget -O- https://www.virtualbox.org/download/oracle_vbox_2016.asc | sudo gpg --yes --output /usr/share/keyrings/oracle-virtualbox-2016.gpg --dearmor
         echo "deb [arch=amd64 signed-by=/usr/share/keyrings/oracle-virtualbox-2016.gpg] https://download.virtualbox.org/virtualbox/debian jammy contrib" | sudo tee /etc/apt/sources.list.d/virtualbox.list
         sudo apt update && sudo apt install virtualbox-7.0
+    - name: "Downgrade VirtualBox"
+      run: |
+        sudo apt-get purge virtualbox-7.0
+        wget -O /tmp/virtualbox-7.0_7.0.14-161095~Ubuntu~jammy_amd64.deb -L https://download.virtualbox.org/virtualbox/7.0.14/virtualbox-7.0_7.0.14-161095~Ubuntu~jammy_amd64.deb
+        sudo dpkg -i /tmp/virtualbox-7.0_7.0.14-161095~Ubuntu~jammy_amd64.deb
     - name: Install the vagrant-vbguest plugin
       run: |
         vagrant plugin install vagrant-vbguest


### PR DESCRIPTION
The latest version of Vagrant doesn't support the newest version of VirtualBox yet. This sets it to the latest working version.