### PR TITLE
Update package changelogs for 1.16.0 release

### DIFF
--- a/debs/jammy/archivematica-storage-service/debian-storage-service/changelog
+++ b/debs/jammy/archivematica-storage-service/debian-storage-service/changelog
@@ -1,3 +1,10 @@
+archivematica-storage-service (1:0.22.0-1~22.04) jammy; urgency=high
+
+  * commit: 262800a2ff546966e65ade4d51ea9bfdfef23bb5
+  * checkout: v0.22.0
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Thu, 16 May 2024 21:46:54 +0000
+
 archivematica-storage-service (1:0.21.1-1~22.04) jammy; urgency=high
 
   * commit: 79b71555a030d52a3601ff632795e809b7fd6f48

--- a/debs/jammy/archivematica/debian-MCPClient/changelog
+++ b/debs/jammy/archivematica/debian-MCPClient/changelog
@@ -1,3 +1,10 @@
+archivematica-mcp-client (1:1.16.0-1~22.04) jammy; urgency=high
+
+  * commit: 48004c5bd798ccb54196720103b462654bf9b08d
+  * checkout: v1.16.0
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Thu, 16 May 2024 21:48:17 +0000
+
 archivematica-mcp-client (1:1.15.1-1~22.04) jammy; urgency=high
 
   * commit: 2c03a79e710d655c3740ddbc4bc62eebd4e4b4fe

--- a/debs/jammy/archivematica/debian-MCPServer/changelog
+++ b/debs/jammy/archivematica/debian-MCPServer/changelog
@@ -1,3 +1,10 @@
+archivematica-mcp-server (1:1.16.0-1~22.04) jammy; urgency=high
+
+  * commit: 48004c5bd798ccb54196720103b462654bf9b08d
+  * checkout: v1.16.0
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Thu, 16 May 2024 21:48:26 +0000
+
 archivematica-mcp-server (1:1.15.1-1~22.04) jammy; urgency=high
 
   * commit: 2c03a79e710d655c3740ddbc4bc62eebd4e4b4fe

--- a/debs/jammy/archivematica/debian-archivematica/changelog
+++ b/debs/jammy/archivematica/debian-archivematica/changelog
@@ -1,3 +1,10 @@
+archivematica (1:1.16.0-1~22.04) jammy; urgency=high
+
+  * commit: 48004c5bd798ccb54196720103b462654bf9b08d
+  * checkout: v1.16.0
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Thu, 16 May 2024 21:44:45 +0000
+
 archivematica (1:1.15.1-1~22.04) jammy; urgency=high
 
   * commit: 2c03a79e710d655c3740ddbc4bc62eebd4e4b4fe

--- a/debs/jammy/archivematica/debian-archivematicaCommon/changelog
+++ b/debs/jammy/archivematica/debian-archivematicaCommon/changelog
@@ -1,3 +1,10 @@
+archivematica-common (1:1.16.0-1~22.04) jammy; urgency=high
+
+  * commit: 48004c5bd798ccb54196720103b462654bf9b08d
+  * checkout: v1.16.0
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Thu, 16 May 2024 21:48:32 +0000
+
 archivematica-common (1:1.15.1-1~22.04) jammy; urgency=high
 
   * commit: 2c03a79e710d655c3740ddbc4bc62eebd4e4b4fe

--- a/debs/jammy/archivematica/debian-dashboard/changelog
+++ b/debs/jammy/archivematica/debian-dashboard/changelog
@@ -1,3 +1,10 @@
+archivematica-dashboard (1:1.16.0-1~22.04) jammy; urgency=high
+
+  * commit: 48004c5bd798ccb54196720103b462654bf9b08d
+  * checkout: v1.16.0
+
+ -- Artefactual Systems <sysadmin@artefactual.com>  Thu, 16 May 2024 21:47:24 +0000
+
 archivematica-dashboard (1:1.15.1-1~22.04) jammy; urgency=high
 
   * commit: 2c03a79e710d655c3740ddbc4bc62eebd4e4b4fe

--- a/rpms/EL9/archivematica-storage-service/changelog
+++ b/rpms/EL9/archivematica-storage-service/changelog
@@ -1,4 +1,7 @@
 %changelog
+* Thu May 16 2024 Artefactual <sysadmin@artefactual.com> - 0.22.0-1
+- Packbuild: 87c39bfb0a0fcad863d8a1d17ffec93b5a1485c5
+- Storage Service: 262800a2ff546966e65ade4d51ea9bfdfef23bb5
 * Mon Feb 19 2024 Artefactual <sysadmin@artefactual.com> - 0.21.1-1
 - Packbuild: 53d71cb2d410052dc2124295efab1bc1df5dda19
 - Storage Service: 79b71555a030d52a3601ff632795e809b7fd6f48

--- a/rpms/EL9/archivematica/changelog
+++ b/rpms/EL9/archivematica/changelog
@@ -1,4 +1,7 @@
 %changelog
+* Thu May 16 2024 Artefactual <sysadmin@artefactual.com> - 1.16.0-1
+- Packbuild: 87c39bfb0a0fcad863d8a1d17ffec93b5a1485c5
+- Archivematica: 48004c5bd798ccb54196720103b462654bf9b08d
 * Mon Feb 19 2024 Artefactual <sysadmin@artefactual.com> - 1.15.1-1
 - Packbuild: 53d71cb2d410052dc2124295efab1bc1df5dda19
 - Archivematica: 2c03a79e710d655c3740ddbc4bc62eebd4e4b4fe


### PR DESCRIPTION
* Update packages changelogs for version 1.16.0

AM 1.16.0 packages:

Jammy AM: https://jenkins-ci.archivematica.org/job/am-packbuild/job/jammy-jenkinsci/160/
Jammy SS: https://jenkins-ci.archivematica.org/job/am-packbuild/job/jammy-jenkinsci/161/
EL9 AM: https://jenkins-ci.archivematica.org/job/am-packbuild/job/rpm-EL9-jenkinsci/223/
EL9 SS: https://jenkins-ci.archivematica.org/job/am-packbuild/job/rpm-EL9-jenkinsci/224/

Connected to https://github.com/archivematica/Issues/issues/1631