### PR TITLE
Override dh_strip to exclude orjson

### DIFF
--- a/debs/jammy/archivematica/debian-archivematica/rules
+++ b/debs/jammy/archivematica/debian-archivematica/rules
@@ -8,3 +8,8 @@ export DH_VIRTUALENV_INSTALL_ROOT=/usr/share/archivematica/virtualenvs
 
 override_dh_virtualenv:
 	dh_virtualenv --python=python3 --requirements=requirements.txt --skip-install
+
+# Ignore orjson because the *.so file included its Python 3.10 wheel contains
+# an 8-byte build ID which debugedit does not support.
+override_dh_strip:
+	dh_strip --exclude=orjson


### PR DESCRIPTION
Ignore `orjson` because the `*.so` file included its Python 3.10 wheel contains an 8-byte build ID which `debugedit` does not support.

This is what the `dh_virtualenv` documentation recommends to [handle problematic binary wheels](https://dh-virtualenv.readthedocs.io/en/latest/howtos.html#handling-binary-wheels).

Connected to https://github.com/archivematica/Issues/issues/1673