### PR TITLE
Fix static assets permissions in AM packages

### DIFF
--- a/debs/jammy/archivematica-storage-service/debian-storage-service/postinst
+++ b/debs/jammy/archivematica-storage-service/debian-storage-service/postinst
@@ -63,6 +63,8 @@ chown -R archivematica:archivematica /var/archivematica/.storage-service
 chown -R archivematica:archivematica ${SS_ENV_DIR}
 mkdir -p /var/log/archivematica/storage-service
 chown -R archivematica:archivematica /var/log/archivematica/storage-service
+chown -R archivematica:archivematica /usr/lib/archivematica/storage-service/assets
+chown -R archivematica:archivematica /usr/lib/archivematica/storage-service/locale
 
 rm -f /tmp/storage_service.log
 

--- a/debs/jammy/archivematica/debian-dashboard/postinst
+++ b/debs/jammy/archivematica/debian-dashboard/postinst
@@ -56,4 +56,8 @@ dashboard::manage collectstatic --noinput --clear
 # Compile messages
 dashboard::manage compilemessages
 
+# Set permissions.
+chown -R archivematica:archivematica /usr/share/archivematica/dashboard/static
+chown -R archivematica:archivematica /usr/share/archivematica/dashboard/locale
+
 #DEBHELPER#

--- a/rpms/EL9/archivematica-storage-service/package.spec
+++ b/rpms/EL9/archivematica-storage-service/package.spec
@@ -123,3 +123,5 @@ bash -c " \
   /usr/share/archivematica/virtualenvs/archivematica-storage-service/bin/python manage.py collectstatic --noinput --clear
   /usr/share/archivematica/virtualenvs/archivematica-storage-service/bin/python manage.py compilemessages
 ";
+chown -R archivematica:archivematica /usr/lib/archivematica/storage-service/assets
+chown -R archivematica:archivematica /usr/lib/archivematica/storage-service/locale

--- a/rpms/EL9/archivematica/archivematica.spec
+++ b/rpms/EL9/archivematica/archivematica.spec
@@ -281,4 +281,6 @@ bash -c " \
   /usr/share/archivematica/virtualenvs/archivematica/bin/python manage.py compilemessages
 ";
 chown -R archivematica:archivematica /var/log/archivematica/dashboard
+chown -R archivematica:archivematica /usr/share/archivematica/dashboard/static
+chown -R archivematica:archivematica /usr/share/archivematica/dashboard/locale
 systemctl daemon-reload

--- a/tests/archivematica/EL9/install.sh
+++ b/tests/archivematica/EL9/install.sh
@@ -224,3 +224,40 @@ sudo -u archivematica bash -c " \
           --ss-api-key="apikey" \
           --site-url="http://localhost"
 ";
+
+sudo -u archivematica bash -c " \
+    set -a -e -x
+    source /etc/default/archivematica-dashboard || \
+        source /etc/sysconfig/archivematica-dashboard \
+            || (echo 'Environment file not found'; exit 1)
+    cd /usr/share/archivematica/dashboard
+      /usr/share/archivematica/virtualenvs/archivematica/bin/python manage.py collectstatic --noinput --clear
+";
+
+sudo -u archivematica bash -c " \
+    set -a -e -x
+    source /etc/default/archivematica-dashboard || \
+        source /etc/sysconfig/archivematica-dashboard \
+            || (echo 'Environment file not found'; exit 1)
+    cd /usr/share/archivematica/dashboard
+      /usr/share/archivematica/virtualenvs/archivematica/bin/python manage.py compilemessages
+";
+
+
+sudo -u archivematica bash -c " \
+    set -a -e -x
+    source /etc/default/archivematica-storage-service || \
+        source /etc/sysconfig/archivematica-storage-service \
+            || (echo 'Environment file not found'; exit 1)
+    cd /usr/lib/archivematica/storage-service
+      /usr/share/archivematica/virtualenvs/archivematica-storage-service/bin/python manage.py collectstatic --noinput --clear
+";
+
+sudo -u archivematica bash -c " \
+    set -a -e -x
+    source /etc/default/archivematica-storage-service || \
+        source /etc/sysconfig/archivematica-storage-service \
+            || (echo 'Environment file not found'; exit 1)
+    cd /usr/lib/archivematica/storage-service
+      /usr/share/archivematica/virtualenvs/archivematica-storage-service/bin/python manage.py compilemessages
+";

--- a/tests/archivematica/jammy/install.sh
+++ b/tests/archivematica/jammy/install.sh
@@ -127,3 +127,40 @@ sudo -u archivematica bash -c " \
           --ss-api-key="apikey" \
           --site-url="http://localhost"
 ";
+
+sudo -u archivematica bash -c " \
+    set -a -e -x
+    source /etc/default/archivematica-dashboard || \
+        source /etc/sysconfig/archivematica-dashboard \
+            || (echo 'Environment file not found'; exit 1)
+    cd /usr/share/archivematica/dashboard
+      /usr/share/archivematica/virtualenvs/archivematica/bin/python manage.py collectstatic --noinput --clear
+";
+
+sudo -u archivematica bash -c " \
+    set -a -e -x
+    source /etc/default/archivematica-dashboard || \
+        source /etc/sysconfig/archivematica-dashboard \
+            || (echo 'Environment file not found'; exit 1)
+    cd /usr/share/archivematica/dashboard
+      /usr/share/archivematica/virtualenvs/archivematica/bin/python manage.py compilemessages
+";
+
+
+sudo -u archivematica bash -c " \
+    set -a -e -x
+    source /etc/default/archivematica-storage-service || \
+        source /etc/sysconfig/archivematica-storage-service \
+            || (echo 'Environment file not found'; exit 1)
+    cd /usr/lib/archivematica/storage-service
+      /usr/share/archivematica/virtualenvs/archivematica-storage-service/bin/python manage.py collectstatic --noinput --clear
+";
+
+sudo -u archivematica bash -c " \
+    set -a -e -x
+    source /etc/default/archivematica-storage-service || \
+        source /etc/sysconfig/archivematica-storage-service \
+            || (echo 'Environment file not found'; exit 1)
+    cd /usr/lib/archivematica/storage-service
+      /usr/share/archivematica/virtualenvs/archivematica-storage-service/bin/python manage.py compilemessages
+";


### PR DESCRIPTION
This sets the `archivematica` user as the owner of the directories used by the `collectstatic` and `compilemessages` management commands in the Archivematica and Storage Service packages which prevents permission errors in subsequent executions of the commands.

Connected to https://github.com/archivematica/Issues/issues/1700