### PR TITLE
Update Archivematica Vagrant box publish workflow

### DIFF
--- a/.github/workflows/vagrant-box-archivematica.yml
+++ b/.github/workflows/vagrant-box-archivematica.yml
@@ -11,15 +11,35 @@ on:
 jobs:
   vagrant-box-archivematica:
     name: Build and upload
-    runs-on: macos-latest
+    runs-on: ubuntu-20.04
     env:
       PACKER_CACHE_DIR: ${{ github.workspace }}/.packer_cache
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+    - name: "Install packer"
+      run: |
+        wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+        echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+        sudo apt update && sudo apt install packer
+    - name: "Install VirtualBox"
+      run: |
+        wget -O- https://www.virtualbox.org/download/oracle_vbox_2016.asc | sudo gpg --yes --output /usr/share/keyrings/oracle-virtualbox-2016.gpg --dearmor
+        echo "deb [arch=amd64 signed-by=/usr/share/keyrings/oracle-virtualbox-2016.gpg] https://download.virtualbox.org/virtualbox/debian $(lsb_release -cs) contrib" | sudo tee /etc/apt/sources.list.d/virtualbox.list
+        sudo apt update && sudo apt install virtualbox-7.0
+    - name: "Downgrade VirtualBox"
+      run: |
+        sudo apt-get purge virtualbox-7.0
+        wget -O /tmp/virtualbox-7.0_7.0.14-161095~Ubuntu~focal_amd64.deb -L https://download.virtualbox.org/virtualbox/7.0.14/virtualbox-7.0_7.0.14-161095~Ubuntu~focal_amd64.deb
+        sudo dpkg -i /tmp/virtualbox-7.0_7.0.14-161095~Ubuntu~focal_amd64.deb
+    - name: Install packer plugins
+      run: |
+        packer plugins install github.com/hashicorp/virtualbox
+        packer plugins install github.com/hashicorp/ansible
+        packer plugins install github.com/hashicorp/vagrant
     - name: Build
       run: |
-        cd ${{ github.workspace }}/packer/templates/vagrant-base-ubuntu-18.04-amd64
+        cd ${{ github.workspace }}/packer/templates/vagrant-base-ubuntu-20.04-amd64
         packer build -on-error=abort template.json
         cd ${{ github.workspace }}/packer/templates/vagrant-box-archivematica
         packer build -on-error=abort template.json

--- a/packer/scripts/ubuntu/ansible-focal.sh
+++ b/packer/scripts/ubuntu/ansible-focal.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -eux
+
+apt-get update -y
+apt-get upgrade -y
+apt-get install -y python3-dev curl git net-tools acl
+
+curl -s https://bootstrap.pypa.io/pip/get-pip.py | python3.8
+pip install ansible==2.9.10 jmespath Jinja2==3.0.3
+
+mkdir -p /etc/ansible
+
+cat << EOF
+[defaults]
+allow_world_readable_tmpfiles = True
+
+[ssh_connection]
+pipelining = True
+EOF

--- a/packer/templates/vagrant-base-ubuntu-20.04-amd64/template.json
+++ b/packer/templates/vagrant-base-ubuntu-20.04-amd64/template.json
@@ -36,7 +36,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_urls": [
         "iso/ubuntu-20.04.1-legacy-server-amd64.iso",
-        "http://cdimage.ubuntu.com/ubuntu-legacy-server/releases/20.04.1/release/ubuntu-20.04.1-legacy-server-amd64.iso"
+        "http://cdimage.ubuntu.com/ubuntu-legacy-server/releases/20.04/release/ubuntu-20.04.1-legacy-server-amd64.iso"
        ],
       "output_directory": "../../builds/virtualbox/vagrant-base-ubuntu-20.04-amd64",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",

--- a/packer/templates/vagrant-box-archivematica/provisioning/group_vars/servers
+++ b/packer/templates/vagrant-box-archivematica/provisioning/group_vars/servers
@@ -2,8 +2,8 @@
 
 # archivematica-src role
 
-archivematica_src_am_version: "v1.14.1"
-archivematica_src_ss_version: "v0.20.1"
+archivematica_src_am_version: "v1.16.0"
+archivematica_src_ss_version: "v0.22.0"
 
 archivematica_src_ss_db_name: "SS"
 archivematica_src_ss_db_user: "ss"
@@ -27,6 +27,9 @@ archivematica_src_ss_environment:
   SS_DB_URL: "mysql://{{ archivematica_src_ss_db_user }}:{{ archivematica_src_ss_db_password }}@{{ archivematica_src_ss_db_host }}:3306/{{ archivematica_src_ss_db_name }}"
 
 # percona role
+
+mysql_version_major: "8"
+mysql_version_minor: "0"
 
 mysql_databases:
   - name: "{{ archivematica_src_am_db_name }}"

--- a/packer/templates/vagrant-box-archivematica/template.json
+++ b/packer/templates/vagrant-box-archivematica/template.json
@@ -2,7 +2,7 @@
   "builders": [
     {
       "type": "virtualbox-ovf",
-      "source_path": "../../builds/virtualbox/vagrant-base-ubuntu-18.04-amd64/vagrant-base-ubuntu-18.04-amd64.ovf",
+      "source_path": "../../builds/virtualbox/vagrant-base-ubuntu-20.04-amd64/vagrant-base-ubuntu-20.04-amd64.ovf",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "30s",

--- a/packer/templates/vagrant-box-archivematica/template.json
+++ b/packer/templates/vagrant-box-archivematica/template.json
@@ -21,7 +21,7 @@
     {
       "execute_command": "echo 'vagrant'|{{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
-        "../../scripts/ubuntu/ansible-bionic.sh"
+        "../../scripts/ubuntu/ansible-focal.sh"
       ],
       "type": "shell"
     },


### PR DESCRIPTION
This updates the workflow to not use macOS runners anymore. It runs on
Ubuntu setting up Packer and VirtualBox explicitly.

The workflow runs on Ubuntu 20.04 because an [issue](https://www.virtualbox.org/ticket/22060) in recent versions
of VirtualBox broke the latest released version of Vagrant.