### PR TITLE
Run AM vagrant box workflow in Ubuntu 24.04

### DIFF
--- a/.github/workflows/vagrant-box-archivematica.yml
+++ b/.github/workflows/vagrant-box-archivematica.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   vagrant-box-archivematica:
     name: Build and upload
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       PACKER_CACHE_DIR: ${{ github.workspace }}/.packer_cache
     steps:
@@ -26,12 +26,11 @@ jobs:
       run: |
         wget -O- https://www.virtualbox.org/download/oracle_vbox_2016.asc | sudo gpg --yes --output /usr/share/keyrings/oracle-virtualbox-2016.gpg --dearmor
         echo "deb [arch=amd64 signed-by=/usr/share/keyrings/oracle-virtualbox-2016.gpg] https://download.virtualbox.org/virtualbox/debian $(lsb_release -cs) contrib" | sudo tee /etc/apt/sources.list.d/virtualbox.list
-        sudo apt update && sudo apt install virtualbox-7.0
-    - name: "Downgrade VirtualBox"
+        sudo apt update && sudo apt install virtualbox-7.1
+    - name: Set the user environment as VirtualBox expects it
       run: |
-        sudo apt-get purge virtualbox-7.0
-        wget -O /tmp/virtualbox-7.0_7.0.14-161095~Ubuntu~focal_amd64.deb -L https://download.virtualbox.org/virtualbox/7.0.14/virtualbox-7.0_7.0.14-161095~Ubuntu~focal_amd64.deb
-        sudo dpkg -i /tmp/virtualbox-7.0_7.0.14-161095~Ubuntu~focal_amd64.deb
+        echo "USER=$USER" >> $GITHUB_ENV
+        echo "LOGNAME=$USER" >> $GITHUB_ENV
     - name: Install packer plugins
       run: |
         packer plugins install github.com/hashicorp/virtualbox

--- a/packer/scripts/ubuntu/ansible-focal.sh
+++ b/packer/scripts/ubuntu/ansible-focal.sh
@@ -5,7 +5,7 @@ apt-get upgrade -y
 apt-get install -y python3-dev curl git net-tools acl
 
 curl -s https://bootstrap.pypa.io/pip/get-pip.py | python3.8
-pip install ansible==2.9.10 jmespath Jinja2==3.0.3
+pip install ansible jmespath Jinja2==3.0.3
 
 mkdir -p /etc/ansible
 

--- a/packer/templates/vagrant-box-archivematica/provisioning/group_vars/servers
+++ b/packer/templates/vagrant-box-archivematica/provisioning/group_vars/servers
@@ -2,8 +2,8 @@
 
 # archivematica-src role
 
-archivematica_src_am_version: "v1.16.0"
-archivematica_src_ss_version: "v0.22.0"
+archivematica_src_am_version: "v1.17.0"
+archivematica_src_ss_version: "v0.23.0"
 
 archivematica_src_ss_db_name: "SS"
 archivematica_src_ss_db_user: "ss"


### PR DESCRIPTION
This also uses the latest version of VirtualBox in the workflow and unpins the `ansible` version to include the `community.mysql` collection [used in the `ansible-archivematica-src` role](https://github.com/artefactual-labs/ansible-archivematica-src/blob/fabbde19033bd01b55cb37d126ada06474d9474f/tasks/configure.yml#L308).