### PR TITLE
Test AM Vagrant box before publishing it

### DIFF
--- a/.github/workflows/vagrant-box-archivematica.yml
+++ b/.github/workflows/vagrant-box-archivematica.yml
@@ -9,24 +9,21 @@ on:
         description: Description
         required: true
 jobs:
-  vagrant-box-archivematica:
-    name: Build and upload
+  build-base-image:
+    name: Build base image
     runs-on: ubuntu-24.04
     env:
       PACKER_CACHE_DIR: ${{ github.workspace }}/.packer_cache
     steps:
     - name: Check out code
       uses: actions/checkout@v4
-    - name: "Install packer"
+    - name: "Install packer and VirtualBox"
       run: |
         wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
         echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
-        sudo apt update && sudo apt install packer
-    - name: "Install VirtualBox"
-      run: |
         wget -O- https://www.virtualbox.org/download/oracle_vbox_2016.asc | sudo gpg --yes --output /usr/share/keyrings/oracle-virtualbox-2016.gpg --dearmor
         echo "deb [arch=amd64 signed-by=/usr/share/keyrings/oracle-virtualbox-2016.gpg] https://download.virtualbox.org/virtualbox/debian $(lsb_release -cs) contrib" | sudo tee /etc/apt/sources.list.d/virtualbox.list
-        sudo apt update && sudo apt install virtualbox-7.1
+        sudo apt update && sudo apt install packer virtualbox-7.1
     - name: Set the user environment as VirtualBox expects it
       run: |
         echo "USER=$USER" >> $GITHUB_ENV
@@ -40,6 +37,43 @@ jobs:
       run: |
         cd ${{ github.workspace }}/packer/templates/vagrant-base-ubuntu-20.04-amd64
         packer build -on-error=abort template.json
+    - name: Upload base image
+      uses: actions/upload-artifact@v4
+      with:
+        name: base-image
+        path: "${{ github.workspace }}/packer/builds/virtualbox/vagrant-base-ubuntu-20.04-amd64"
+  vagrant-box-archivematica:
+    name: Build and upload box image
+    runs-on: ubuntu-24.04
+    needs: ["build-base-image"]
+    env:
+      PACKER_CACHE_DIR: ${{ github.workspace }}/.packer_cache
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+    - name: Restore base image
+      uses: actions/download-artifact@v4
+      with:
+        name: base-image
+        path: "${{ github.workspace }}/packer/builds/virtualbox/vagrant-base-ubuntu-20.04-amd64"
+    - name: "Install packer and VirtualBox"
+      run: |
+        wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+        echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+        wget -O- https://www.virtualbox.org/download/oracle_vbox_2016.asc | sudo gpg --yes --output /usr/share/keyrings/oracle-virtualbox-2016.gpg --dearmor
+        echo "deb [arch=amd64 signed-by=/usr/share/keyrings/oracle-virtualbox-2016.gpg] https://download.virtualbox.org/virtualbox/debian $(lsb_release -cs) contrib" | sudo tee /etc/apt/sources.list.d/virtualbox.list
+        sudo apt update && sudo apt install packer virtualbox-7.1
+    - name: Set the user environment as VirtualBox expects it
+      run: |
+        echo "USER=$USER" >> $GITHUB_ENV
+        echo "LOGNAME=$USER" >> $GITHUB_ENV
+    - name: Install packer plugins
+      run: |
+        packer plugins install github.com/hashicorp/virtualbox
+        packer plugins install github.com/hashicorp/ansible
+        packer plugins install github.com/hashicorp/vagrant
+    - name: Build
+      run: |
         cd ${{ github.workspace }}/packer/templates/vagrant-box-archivematica
         packer build -on-error=abort template.json
         mv ${{ github.workspace }}/packer/builds/virtualbox/vagrant-am.box \

--- a/.github/workflows/vagrant-box-archivematica.yml
+++ b/.github/workflows/vagrant-box-archivematica.yml
@@ -8,9 +8,6 @@ on:
       description:
         description: Description
         required: true
-  push:
-    branches:
-      - "dev/test-am-vagrant-workflow"
 jobs:
   build-base-image:
     name: Build base image
@@ -84,15 +81,12 @@ jobs:
         cd ${{ github.workspace }}/packer/templates/vagrant-box-archivematica
         packer build -on-error=abort template.json
         mv ${{ github.workspace }}/packer/builds/virtualbox/vagrant-am.box \
-          ${{ github.workspace }}/archivematica-vagrant-v1.17.0.box
+          ${{ github.workspace }}/archivematica-vagrant-${{ github.event.inputs.version }}.box
     - name: Provision a test VM with the new image
       run: |
-        vagrant init --minimal --no-tty archivematica-vagrant-v1.17.0 file://${{ github.workspace }}/archivematica-vagrant-v1.17.0.box
+        vagrant init --minimal --no-tty archivematica-vagrant-${{ github.event.inputs.version }} file://${{ github.workspace }}/archivematica-vagrant-${{ github.event.inputs.version }}.box
         cat Vagrantfile
         vagrant up --debug-timestamp --provider virtualbox
-    - name: Print Python versions installed
-      run: |
-        vagrant ssh -c "ls -altr /usr/bin/python*"
     - name: Test AM is running in the test VM
       run: |
         sleep 180
@@ -112,13 +106,13 @@ jobs:
                 'http://10.10.10.20:8000/api/v2/pipeline/' \
             | jq -r '.meta.total_count == 1' \
         ) == true
-    # - name: Upload
-    #   run: |
-    #     cd ${{ github.workspace }}/tools/vagrant-box-uploader
-    #     bundle install
-    #     ruby upload.rb \
-    #       archivematica \
-    #       '${{ github.workspace }}/archivematica-vagrant-${{ github.event.inputs.version }}.box' \
-    #       '${{ secrets.VAGRANT_CLOUD }}' \
-    #       '${{ github.event.inputs.version }}' \
-    #       '${{ github.event.inputs.description }}'
+    - name: Upload
+      run: |
+        cd ${{ github.workspace }}/tools/vagrant-box-uploader
+        bundle install
+        ruby upload.rb \
+          archivematica \
+          '${{ github.workspace }}/archivematica-vagrant-${{ github.event.inputs.version }}.box' \
+          '${{ secrets.VAGRANT_CLOUD }}' \
+          '${{ github.event.inputs.version }}' \
+          '${{ github.event.inputs.description }}'

--- a/.github/workflows/vagrant-box-archivematica.yml
+++ b/.github/workflows/vagrant-box-archivematica.yml
@@ -8,6 +8,9 @@ on:
       description:
         description: Description
         required: true
+  push:
+    branches:
+      - "dev/test-am-vagrant-workflow"
 jobs:
   build-base-image:
     name: Build base image
@@ -81,12 +84,15 @@ jobs:
         cd ${{ github.workspace }}/packer/templates/vagrant-box-archivematica
         packer build -on-error=abort template.json
         mv ${{ github.workspace }}/packer/builds/virtualbox/vagrant-am.box \
-          ${{ github.workspace }}/archivematica-vagrant-${{ github.event.inputs.version }}.box
+          ${{ github.workspace }}/archivematica-vagrant-v1.17.0.box
     - name: Provision a test VM with the new image
       run: |
-        vagrant init --minimal --no-tty archivematica-vagrant-${{ github.event.inputs.version }} file://${{ github.workspace }}/archivematica-vagrant-${{ github.event.inputs.version }}.box
+        vagrant init --minimal --no-tty archivematica-vagrant-v1.17.0 file://${{ github.workspace }}/archivematica-vagrant-v1.17.0.box
         cat Vagrantfile
         vagrant up --debug-timestamp --provider virtualbox
+    - name: Print Python versions installed
+      run: |
+        vagrant ssh -c "ls -altr /usr/bin/python*"
     - name: Test AM is running in the test VM
       run: |
         sleep 180
@@ -106,13 +112,13 @@ jobs:
                 'http://10.10.10.20:8000/api/v2/pipeline/' \
             | jq -r '.meta.total_count == 1' \
         ) == true
-    - name: Upload
-      run: |
-        cd ${{ github.workspace }}/tools/vagrant-box-uploader
-        bundle install
-        ruby upload.rb \
-          archivematica \
-          '${{ github.workspace }}/archivematica-vagrant-${{ github.event.inputs.version }}.box' \
-          '${{ secrets.VAGRANT_CLOUD }}' \
-          '${{ github.event.inputs.version }}' \
-          '${{ github.event.inputs.description }}'
+    # - name: Upload
+    #   run: |
+    #     cd ${{ github.workspace }}/tools/vagrant-box-uploader
+    #     bundle install
+    #     ruby upload.rb \
+    #       archivematica \
+    #       '${{ github.workspace }}/archivematica-vagrant-${{ github.event.inputs.version }}.box' \
+    #       '${{ secrets.VAGRANT_CLOUD }}' \
+    #       '${{ github.event.inputs.version }}' \
+    #       '${{ github.event.inputs.description }}'

--- a/.github/workflows/vagrant-box-archivematica.yml
+++ b/.github/workflows/vagrant-box-archivematica.yml
@@ -56,17 +56,21 @@ jobs:
       with:
         name: base-image
         path: "${{ github.workspace }}/packer/builds/virtualbox/vagrant-base-ubuntu-20.04-amd64"
-    - name: "Install packer and VirtualBox"
+    - name: "Install packer, vagrant and VirtualBox"
       run: |
         wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
         echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
         wget -O- https://www.virtualbox.org/download/oracle_vbox_2016.asc | sudo gpg --yes --output /usr/share/keyrings/oracle-virtualbox-2016.gpg --dearmor
         echo "deb [arch=amd64 signed-by=/usr/share/keyrings/oracle-virtualbox-2016.gpg] https://download.virtualbox.org/virtualbox/debian $(lsb_release -cs) contrib" | sudo tee /etc/apt/sources.list.d/virtualbox.list
-        sudo apt update && sudo apt install packer virtualbox-7.1
+        sudo apt update && sudo apt install packer vagrant virtualbox-7.1
     - name: Set the user environment as VirtualBox expects it
       run: |
         echo "USER=$USER" >> $GITHUB_ENV
         echo "LOGNAME=$USER" >> $GITHUB_ENV
+    - name: Update vbox networks
+      run: |
+        sudo mkdir -p /etc/vbox/
+        echo "* 10.10.10.20/24" | sudo tee -a /etc/vbox/networks.conf
     - name: Install packer plugins
       run: |
         packer plugins install github.com/hashicorp/virtualbox
@@ -78,6 +82,30 @@ jobs:
         packer build -on-error=abort template.json
         mv ${{ github.workspace }}/packer/builds/virtualbox/vagrant-am.box \
           ${{ github.workspace }}/archivematica-vagrant-${{ github.event.inputs.version }}.box
+    - name: Provision a test VM with the new image
+      run: |
+        vagrant init --minimal --no-tty archivematica-vagrant-${{ github.event.inputs.version }} file://${{ github.workspace }}/archivematica-vagrant-${{ github.event.inputs.version }}.box
+        cat Vagrantfile
+        vagrant up --debug-timestamp --provider virtualbox
+    - name: Test AM is running in the test VM
+      run: |
+        sleep 180
+        test $( \
+            curl \
+                --silent \
+                --header 'Authorization: ApiKey admin:this_is_the_am_api_key' \
+                --header 'Content-Type: application/json' \
+                'http://10.10.10.20/api/processing-configuration/' \
+            | jq -r '.processing_configurations == ["automated", "default"]' \
+        ) == true
+        test $( \
+            curl \
+                --silent \
+                --header 'Authorization: ApiKey admin:this_is_the_ss_api_key' \
+                --header 'Content-Type: application/json' \
+                'http://10.10.10.20:8000/api/v2/pipeline/' \
+            | jq -r '.meta.total_count == 1' \
+        ) == true
     - name: Upload
       run: |
         cd ${{ github.workspace }}/tools/vagrant-box-uploader

--- a/packer/scripts/ubuntu/cleanup.sh
+++ b/packer/scripts/ubuntu/cleanup.sh
@@ -21,12 +21,6 @@ dpkg --list \
     | grep linux-source \
     | xargs apt-get -y purge;
 
-# Delete development packages
-dpkg --list \
-    | awk '{ print $2 }' \
-    | grep -- '-dev$' \
-    | xargs apt-get -y purge;
-
 # delete docs packages
 dpkg --list \
     | awk '{ print $2 }' \


### PR DESCRIPTION
While testing https://github.com/artefactual-labs/am-packbuild/pull/364 locally I noticed that the AM vagrant box build finishes successfully but the AM services do not start due to Python 3.9 missing.

The reason is [this block in the clean up process](https://github.com/artefactual-labs/am-packbuild/blob/21ea4e7aa47aa1f956831a7a9f85e558d96337ef/packer/scripts/ubuntu/cleanup.sh#L24-L28):

```shell
# Delete development packages
dpkg --list \
    | awk '{ print $2 }' \
    | grep -- '-dev$' \
    | xargs apt-get -y purge;
```

That expression is too loose and it matches `python3.9-dev` among other important libraries for AM.

So, this adds steps to test the Vagrant box created through the `Archivematica Vagrant box` CI workflow.

In the commits of the pull request you can see how the new test fails in https://github.com/artefactual-labs/am-packbuild/tree/b4c7fb99e81ff20e92c4bcf42a657d569d1206d0 because Python 3.9 has been deleted:

![imagen](https://github.com/user-attachments/assets/edd37c36-a87e-43b6-a795-ced637884b68)

Then after removing the block from the clean up file above the test passes in https://github.com/artefactual-labs/am-packbuild/tree/32b3184a92f99c37228b64be2509987238e82a14.

I also split the workflow into two jobs, one for building the base image and one for building, testing and publishing the AM box image. This saves time if the AM box build fails but the base image has been created successfully and the workflow needs to be retried.

Connected to https://github.com/archivematica/Issues/issues/1720