### PR TITLE
Reorganize Ubuntu base template variables

### DIFF
--- a/packer/templates/vagrant-base-ubuntu-20.04-amd64/template.json.pkr.hcl
+++ b/packer/templates/vagrant-base-ubuntu-20.04-amd64/template.json.pkr.hcl
@@ -75,6 +75,11 @@ variable "boot_command" {
   ]
 }
 
+variable "http_directory" {
+  type    = string
+  default = "../../http/ubuntu-cloud-init"
+}
+
 source "virtualbox-iso" "ubuntu" {
   boot_command            = "${var.boot_command}"
   boot_wait               = "5s"
@@ -82,7 +87,7 @@ source "virtualbox-iso" "ubuntu" {
   guest_os_type           = "Ubuntu_64"
   hard_drive_interface    = "sata"
   headless                = "${var.headless}"
-  http_directory          = "../../http/ubuntu-cloud-init"
+  http_directory          = "${var.http_directory}"
   iso_checksum            = "${var.iso_checksum}"
   iso_url                 = "${var.iso_url}"
   output_directory        = "../../builds/virtualbox/vagrant-base-ubuntu-20.04-amd64"

--- a/packer/templates/vagrant-base-ubuntu-20.04-amd64/template.json.pkr.hcl
+++ b/packer/templates/vagrant-base-ubuntu-20.04-amd64/template.json.pkr.hcl
@@ -85,9 +85,14 @@ variable "output_directory" {
   default = "../../builds/virtualbox/vagrant-base-ubuntu-20.04-amd64"
 }
 
+variable "boot_wait" {
+  type    = string
+  default = "5s"
+}
+
 source "virtualbox-iso" "ubuntu" {
   boot_command            = "${var.boot_command}"
-  boot_wait               = "5s"
+  boot_wait               = "${var.boot_wait}"
   disk_size               = "${var.disk_size}"
   guest_os_type           = "Ubuntu_64"
   hard_drive_interface    = "sata"

--- a/packer/templates/vagrant-base-ubuntu-20.04-amd64/template.json.pkr.hcl
+++ b/packer/templates/vagrant-base-ubuntu-20.04-amd64/template.json.pkr.hcl
@@ -47,7 +47,7 @@ variable "no_proxy" {
   default = "${env("no_proxy")}"
 }
 
-variable "template" {
+variable "vm_name" {
   type    = string
   default = "vagrant-base-ubuntu-20.04-amd64"
 }
@@ -96,7 +96,7 @@ source "virtualbox-iso" "ubuntu" {
     ["modifyvm", "{{ .Name }}", "--cpus", "${var.cpus}"]
   ]
   virtualbox_version_file = ".vbox_version"
-  vm_name                 = "${var.template}"
+  vm_name                 = "${var.vm_name}"
 }
 
 build {

--- a/packer/templates/vagrant-base-ubuntu-20.04-amd64/template.json.pkr.hcl
+++ b/packer/templates/vagrant-base-ubuntu-20.04-amd64/template.json.pkr.hcl
@@ -80,6 +80,11 @@ variable "http_directory" {
   default = "../../http/ubuntu-cloud-init"
 }
 
+variable "output_directory" {
+  type    = string
+  default = "../../builds/virtualbox/vagrant-base-ubuntu-20.04-amd64"
+}
+
 source "virtualbox-iso" "ubuntu" {
   boot_command            = "${var.boot_command}"
   boot_wait               = "5s"
@@ -90,7 +95,7 @@ source "virtualbox-iso" "ubuntu" {
   http_directory          = "${var.http_directory}"
   iso_checksum            = "${var.iso_checksum}"
   iso_url                 = "${var.iso_url}"
-  output_directory        = "../../builds/virtualbox/vagrant-base-ubuntu-20.04-amd64"
+  output_directory        = "${var.output_directory}"
   shutdown_command        = "echo 'vagrant' | sudo -S shutdown -P now"
   ssh_password            = "vagrant"
   ssh_port                = 22

--- a/packer/templates/vagrant-base-ubuntu-20.04-amd64/template.json.pkr.hcl
+++ b/packer/templates/vagrant-base-ubuntu-20.04-amd64/template.json.pkr.hcl
@@ -57,8 +57,9 @@ variable "iso_url" {
   default = "https://www.releases.ubuntu.com/20.04/ubuntu-20.04.6-live-server-amd64.iso"
 }
 
-source "virtualbox-iso" "ubuntu" {
-  boot_command            = [
+variable "boot_command" {
+  type    = list(string)
+  default = [
     # Display language menu.
     "<wait><enter><wait>",
     # Select English.
@@ -72,6 +73,10 @@ source "virtualbox-iso" "ubuntu" {
     # Boot.
     "<enter><wait>"
   ]
+}
+
+source "virtualbox-iso" "ubuntu" {
+  boot_command            = "${var.boot_command}"
   boot_wait               = "5s"
   disk_size               = "${var.disk_size}"
   guest_os_type           = "Ubuntu_64"

--- a/packer/templates/vagrant-base-ubuntu-20.04-amd64/template.json.pkr.hcl
+++ b/packer/templates/vagrant-base-ubuntu-20.04-amd64/template.json.pkr.hcl
@@ -34,7 +34,7 @@ variable "https_proxy" {
 
 variable "iso_checksum" {
   type    = string
-  default = "b8f31413336b9393ad5d8ef0282717b2ab19f007df2e9ed5196c13d8f9153c8b"
+  default = "file:https://releases.ubuntu.com/20.04/SHA256SUMS"
 }
 
 variable "memory" {

--- a/packer/templates/vagrant-base-ubuntu-20.04-amd64/template.json.pkr.hcl
+++ b/packer/templates/vagrant-base-ubuntu-20.04-amd64/template.json.pkr.hcl
@@ -52,6 +52,11 @@ variable "template" {
   default = "vagrant-base-ubuntu-20.04-amd64"
 }
 
+variable "iso_url" {
+  type    = string
+  default = "https://www.releases.ubuntu.com/20.04/ubuntu-20.04.6-live-server-amd64.iso"
+}
+
 source "virtualbox-iso" "ubuntu" {
   boot_command            = [
     # Display language menu.
@@ -74,10 +79,7 @@ source "virtualbox-iso" "ubuntu" {
   headless                = "${var.headless}"
   http_directory          = "../../http/ubuntu-cloud-init"
   iso_checksum            = "${var.iso_checksum}"
-  iso_urls                = [
-    "iso/ubuntu-20.04.6-live-server-amd64.iso",
-    "https://www.releases.ubuntu.com/20.04/ubuntu-20.04.6-live-server-amd64.iso"
-  ]
+  iso_url                 = "${var.iso_url}"
   output_directory        = "../../builds/virtualbox/vagrant-base-ubuntu-20.04-amd64"
   shutdown_command        = "echo 'vagrant' | sudo -S shutdown -P now"
   ssh_password            = "vagrant"


### PR DESCRIPTION
This extracts a few `virtualbox-iso` [configuration options](https://developer.hashicorp.com/packer/integrations/hashicorp/virtualbox/latest/components/builder/iso#virtualbox-iso-builder-configuration-reference) in the Ubuntu 20.04 base template into new variables to simplify overrides from new Ubuntu versions.

Connected to https://github.com/archivematica/Issues/issues/1720