### PR TITLE
Upgrade setuptools in AM package builder scripts

### DIFF
--- a/debs/jammy/archivematica-storage-service/debian-storage-service/rules
+++ b/debs/jammy/archivematica-storage-service/debian-storage-service/rules
@@ -7,4 +7,4 @@ export DH_VIRTUALENV_INSTALL_ROOT=/usr/share/archivematica/virtualenvs
 	dh $@ --with python-virtualenv --with systemd
 
 override_dh_virtualenv:
-	dh_virtualenv --python=python3 --requirements=requirements.txt --skip-install
+	dh_virtualenv --python=python3 --preinstall "setuptools>=75" --requirements=requirements.txt --skip-install

--- a/debs/jammy/archivematica/debian-archivematica/rules
+++ b/debs/jammy/archivematica/debian-archivematica/rules
@@ -7,7 +7,7 @@ export DH_VIRTUALENV_INSTALL_ROOT=/usr/share/archivematica/virtualenvs
 	dh $@ --with python-virtualenv
 
 override_dh_virtualenv:
-	dh_virtualenv --python=python3 --requirements=requirements.txt --skip-install
+	dh_virtualenv --python=python3 --preinstall "setuptools>=75" --requirements=requirements.txt --skip-install
 
 # Ignore orjson because the *.so file included its Python 3.10 wheel contains
 # an 8-byte build ID which debugedit does not support.

--- a/rpms/EL9/archivematica-storage-service/package.spec
+++ b/rpms/EL9/archivematica-storage-service/package.spec
@@ -58,7 +58,7 @@ mkdir -p \
   %{buildroot}/etc/nginx/conf.d
 
 virtualenv /usr/share/archivematica/virtualenvs/archivematica-storage-service
-/usr/share/archivematica/virtualenvs/archivematica-storage-service/bin/pip install --upgrade pip
+/usr/share/archivematica/virtualenvs/archivematica-storage-service/bin/pip install --upgrade pip setuptools
 /usr/share/archivematica/virtualenvs/archivematica-storage-service/bin/pip install -r %{_sourcedir}/%{name}/requirements.txt
 cp -rf /usr/share/archivematica/virtualenvs/archivematica-storage-service/* %{buildroot}/usr/share/archivematica/virtualenvs/archivematica-storage-service/
 

--- a/rpms/EL9/archivematica/archivematica.spec
+++ b/rpms/EL9/archivematica/archivematica.spec
@@ -166,7 +166,7 @@ mkdir -p \
 
 # Archivematica virtual environment
 virtualenv /usr/share/archivematica/virtualenvs/archivematica
-/usr/share/archivematica/virtualenvs/archivematica/bin/pip install --upgrade pip
+/usr/share/archivematica/virtualenvs/archivematica/bin/pip install --upgrade pip setuptools
 /usr/share/archivematica/virtualenvs/archivematica/bin/pip install -r %{_sourcedir}/%{name}/requirements.txt
 cp -rf /usr/share/archivematica/virtualenvs/archivematica/* %{buildroot}/usr/share/archivematica/virtualenvs/archivematica/
 


### PR DESCRIPTION
The Archivematica and Storage Service installation requires `setuptools` and `setuptools-scm` to build Python packages from GitHub.

As of version 8.2.0, `setuptools-scm` requires `setuptools` 61 or later, which is newer than the default version provided by the builder images.

This update ensures all package builder scripts upgrade `setuptools` accordingly.

Connected to https://github.com/archivematica/Issues/issues/1720