### PR TITLE
Use the vagrant CLI for publishing Vagrant boxes

### DIFF
--- a/.github/workflows/vagrant-box-archivematica.yml
+++ b/.github/workflows/vagrant-box-archivematica.yml
@@ -58,9 +58,26 @@ jobs:
         ubuntu-version: [
           "22.04",
         ]
+    permissions:
+      contents: "read"
+      id-token: "write"
     steps:
     - name: Check out code
       uses: actions/checkout@v4
+    - name: Set up HCP authentication
+      uses: hashicorp/hcp-auth-action@v0
+      with:
+        workload_identity_provider: "${{ secrets.HCP_WORKLOAD_IDENTITY_PROVIDER }}"
+        set_access_token: true
+    - name: Set up the HCP CLI
+      uses: hashicorp/hcp-setup-action@v0
+      with:
+        version: "latest"
+    - name: Set the Vagrant Cloud token
+      run: |
+        VAGRANT_CLOUD_TOKEN="$(hcp auth print-access-token)"
+        echo "::add-mask::$VAGRANT_CLOUD_TOKEN"
+        echo "VAGRANT_CLOUD_TOKEN=$VAGRANT_CLOUD_TOKEN" >> $GITHUB_ENV
     - name: Restore base image
       uses: actions/download-artifact@v4
       with:
@@ -114,11 +131,10 @@ jobs:
         ) == true
     - name: Upload
       run: |
-        cd ${{ github.workspace }}/tools/vagrant-box-uploader
-        bundle install
-        ruby upload.rb \
-          archivematica \
-          '${{ github.workspace }}/archivematica-vagrant-${{ github.event.inputs.version }}.box' \
-          '${{ secrets.VAGRANT_CLOUD }}' \
-          '${{ github.event.inputs.version }}' \
-          '${{ github.event.inputs.description }}'
+        vagrant cloud publish \
+            --force \
+            --version-description '${{ github.event.inputs.description }}' \
+            artefactual/archivematica \
+            '${{ github.event.inputs.version }}' \
+            virtualbox \
+            '${{ github.workspace }}/archivematica-vagrant-${{ github.event.inputs.version }}.box'

--- a/.github/workflows/vagrant-box-atom.yml
+++ b/.github/workflows/vagrant-box-atom.yml
@@ -58,9 +58,26 @@ jobs:
         ubuntu-version: [
           "24.04",
         ]
+    permissions:
+      contents: "read"
+      id-token: "write"
     steps:
     - name: Check out code
       uses: actions/checkout@v4
+    - name: Set up HCP authentication
+      uses: hashicorp/hcp-auth-action@v0
+      with:
+        workload_identity_provider: "${{ secrets.HCP_WORKLOAD_IDENTITY_PROVIDER }}"
+        set_access_token: true
+    - name: Set up the HCP CLI
+      uses: hashicorp/hcp-setup-action@v0
+      with:
+        version: "latest"
+    - name: Set the Vagrant Cloud token
+      run: |
+        VAGRANT_CLOUD_TOKEN="$(hcp auth print-access-token)"
+        echo "::add-mask::$VAGRANT_CLOUD_TOKEN"
+        echo "VAGRANT_CLOUD_TOKEN=$VAGRANT_CLOUD_TOKEN" >> $GITHUB_ENV
     - name: Restore base image
       uses: actions/download-artifact@v4
       with:
@@ -115,11 +132,10 @@ jobs:
         ) == true
     - name: Upload
       run: |
-        cd ${{ github.workspace }}/tools/vagrant-box-uploader
-        bundle install
-        ruby upload.rb \
-          atom \
-          '${{ github.workspace }}/atom-vagrant-${{ github.event.inputs.version }}.box' \
-          '${{ secrets.VAGRANT_CLOUD }}' \
-          '${{ github.event.inputs.version }}' \
-          '${{ github.event.inputs.description }}'
+        vagrant cloud publish \
+            --force \
+            --version-description '${{ github.event.inputs.description }}' \
+            artefactual/atom \
+            '${{ github.event.inputs.version }}' \
+            virtualbox \
+            '${{ github.workspace }}/atom-vagrant-${{ github.event.inputs.version }}.box'


### PR DESCRIPTION
This replaces the old `vagrant-box-uploader` tool with the [`vagrant cloud publish`](https://developer.hashicorp.com/vagrant/docs/cli/cloud#cloud-publish) command in the GitHub workflows for publishing Archivematica and AtoM Vagrant boxes.