### PR TITLE
Enable external JHOVE modules in EL9 RPM

### DIFF
--- a/rpms/EL9/jhove/files/jhove
+++ b/rpms/EL9/jhove/files/jhove
@@ -20,7 +20,7 @@ for i in $(find /usr/share/jhove/bin/ -name *.jar ! -name jhove*jar);do
      fi
 done
 
-CONFIG="/usr/share/jhove/conf/jhove.conf"
+CONFIG="/usr/share/jhove/conf/ext-modules/jhove.conf"
 
 # Set class path and invoke Java
 java -Xss1024k -classpath "${jar_list}:${extra_jar_list}" edu.harvard.hul.ois.jhove.Jhove -c "${CONFIG}" "${@}"

--- a/rpms/EL9/jhove/files/jhove-gui
+++ b/rpms/EL9/jhove/files/jhove-gui
@@ -20,7 +20,7 @@ for i in $(find /usr/share/jhove/bin/ -name *.jar ! -name jhove*jar);do
      fi
 done
 
-CONFIG="/usr/share/jhove/conf/jhove.conf"
+CONFIG="/usr/share/jhove/conf/ext-modules/jhove.conf"
 
 # Set class path and invoke Java
 java -Xss1024k -classpath "${jar_list}:${extra_jar_list}" edu.harvard.hul.ois.jhove.viewer.JhoveView -c "${CONFIG}" "${@}"

--- a/rpms/EL9/jhove/package.spec
+++ b/rpms/EL9/jhove/package.spec
@@ -42,6 +42,8 @@ cp -rf lib %{buildroot}/usr/share/jhove/
 cp LICENSE README.md COPYING %{buildroot}/usr/share/doc/jhove/
 
 %changelog
+* Fri Apr 11 2025 - sysadmin@artefactual.com
+- 1.32.1-2 package: Enable external JHOVE modules
 * Thu Mar 13 2025 - sysadmin@artefactual.com
 - 1.32.1-1 package: Bump version to 1.32.1
 * Mon Sep 25 2023 - sysadmin@artefactual.com


### PR DESCRIPTION
This change updates the configuration file paths in the `jhove` and `jhove-gui` scripts to use the configuration that enables all external JHOVE modules.

https://github.com/archivematica/Issues/issues/1720