### PR TITLE
Enable arm64 builds in siegfried pkg

### DIFF
--- a/debs/siegfried/Dockerfile
+++ b/debs/siegfried/Dockerfile
@@ -1,9 +1,11 @@
 FROM ubuntu:xenial
 
 # Environmnet variables needed during build
-ENV GOVERSION 1.24.1
-ENV GOOS linux
-ENV GOARCH amd64
+ARG GOVERSION=1.24.1
+ARG GOOS=linux
+ARG GOARCH=amd64
+ENV GOOS=${GOOS}
+ENV GOARCH=${GOARCH}
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Environment variables needed during runtime

--- a/debs/siegfried/Makefile
+++ b/debs/siegfried/Makefile
@@ -9,13 +9,15 @@ DOCKER_VOLUME = "/src"
 DOCKER_IMAGE  = "debbuild-$(NAME)-$(VERSION)"
 GPG_ID        ?= 0F4A4D31
 DISTRO_CODENAME = xenial
+GOOS          ?= linux
+GOARCH        ?= amd64
 .PHONY: build-docker-image build deb-build deb-clean deb-test
 
 all: build-docker-image get-code build
 
 build-docker-image:
 	@echo "==> Building Docker image with build environment."
-	@docker build --rm --tag "$(DOCKER_IMAGE)"  .
+	@docker build --rm --build-arg GOOS=$(GOOS) --build-arg GOARCH=$(GOARCH) --tag "$(DOCKER_IMAGE)"  .
 
 build:
 	@echo "==> Building deb."
@@ -27,24 +29,30 @@ build:
 				-e BUILD_TYPE=$(BUILD_TYPE) \
 				-e GPG_ID=$(GPG_ID) \
 				-e GPG_KEY \
+				-e GOOS=$(GOOS) \
+				-e GOARCH=$(GOARCH) \
 		--volume "$(shell pwd):$(DOCKER_VOLUME)" $(DOCKER_IMAGE) make -C $(DOCKER_VOLUME) deb-build
 
 deb-build:
 	@echo "==> Install gpg keys."
 	@if [ -f "$(DOCKER_VOLUME)/GPG-KEY" ]; then gpg --import $(DOCKER_VOLUME)/GPG-KEY; fi
 	@if [ x"$$GPG_KEY" != x ]; then echo "$$GPG_KEY" | gpg --import - ; fi
-	@echo "==> Clone code"
-	# Update debian/folder and changelog, and install dependencies
-	@cp debian src/$(PACKAGE) -rf
-	@cd src/$(PACKAGE) && \
+	@echo "==> Prepare isolated build workspace."
+	@WORKDIR="/tmp/build-$(PACKAGE)"; \
+	rm -rf "$$WORKDIR" && mkdir -p "$$WORKDIR" && \
+	echo "==> Clone code" && \
+	cp -a src/$(PACKAGE) "$$WORKDIR"/ && \
+	cp -a debian "$$WORKDIR"/$(PACKAGE)/ && \
+	echo "==> Update changelog and install build-deps" && \
+	cd "$$WORKDIR/$(PACKAGE)" && \
 	dch -v ${VERSION}-${RELEASE} Commit $(shell cat src/$(PACKAGE)/.git/HEAD) && \
 	dch -r --distribution $(DISTRO_CODENAME) --urgency medium ignored && \
-	yes | mk-build-deps --install debian/control
-	@echo "==> Build package."
-	cd src/$(PACKAGE) && PATH=${PATH} GOPATH=${GOPATH} dpkg-buildpackage -k${GPG_ID}
-	@echo "==> Copying DEB files."
-	mkdir -p build
-	cp src/$(PACKAGE)_* build/
+	yes | mk-build-deps --install debian/control && \
+	echo "==> Build package." && \
+	PATH=${PATH} GOPATH=${GOPATH} dpkg-buildpackage -k${GPG_ID} && \
+	echo "==> Copying DEB files." && \
+	mkdir -p "$(DOCKER_VOLUME)/build" && \
+	cp "$$WORKDIR"/$(PACKAGE)_* "$(DOCKER_VOLUME)/build/"
 
 get-code:
 	@echo "==> Get code."


### PR DESCRIPTION
Propagate GOOS and GOARCH env strings so we can choose build targets when invoking make.

Also, build the package off the shared volume by copying the tree to the container filesystem and then build from there. It prevents `dh_fixperms` from failing when running `chown --no-dereference 0:0` in certain shared modules like virtiofs in macOS.

Note: cross-compilation is still unsupported but should be possible, i.e. download the go toolchain for the local architecture and derive the deb arch config from the envs.