### PR TITLE
Enable arm64 builds in siegfried rpms

### DIFF
--- a/rpms/EL8/siegfried/Dockerfile
+++ b/rpms/EL8/siegfried/Dockerfile
@@ -1,13 +1,15 @@
 FROM rockylinux:8
 
-# Environmnet variables needed during build
-ENV GOVERSION 1.24.1
-ENV GOOS linux
-ENV GOARCH amd64
+ARG GOVERSION=1.24.1
+ARG GOOS=linux
+ARG GOARCH=amd64
 
 # Environment variables needed during runtime
-ENV GOPATH /go
-ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/go/bin
+ENV GOPATH=/go
+ENV PATH="/usr/local/go/bin:${PATH}"
+ENV GOVERSION=${GOVERSION}
+ENV GOOS=${GOOS}
+ENV GOARCH=${GOARCH}
 
 RUN yum -y install rpm-build make git && \
 	curl -sO https://storage.googleapis.com/golang/go${GOVERSION}.${GOOS}-${GOARCH}.tar.gz && \

--- a/rpms/EL8/siegfried/Makefile
+++ b/rpms/EL8/siegfried/Makefile
@@ -4,11 +4,21 @@ RPM_TOPDIR    = "/rpmbuild"
 DOCKER_VOLUME = "/src"
 DOCKER_IMAGE  = "rpmbuild-$(NAME)-$(VERSION)"
 SIEGFRIED_SRC = "/go/src/github.com/richardlehane/siegfried"
+GOOS          ?= linux
+GOARCH        ?= amd64
+
+RPM_ARCH = $(GOARCH)
+ifeq ($(GOARCH),amd64)
+  RPM_ARCH = x86_64
+else ifeq ($(GOARCH),arm64)
+  RPM_ARCH = aarch64
+endif
 
 RPMBUILD_ARGS := \
 	--define "_topdir $(RPM_TOPDIR)" \
 	--define "name $(NAME)" \
-	--define "version $(VERSION)"
+	--define "version $(VERSION)" \
+	--target "$(RPM_ARCH)"
 
 .PHONY: build-docker-image build rpm-build rpm-clean rpm-test
 
@@ -16,11 +26,18 @@ all: build-docker-image build
 
 build-docker-image:
 	@echo "==> Building Docker image with build environment."
-	@docker build --tag "${DOCKER_IMAGE}" .
+	@docker build \
+		--build-arg GOOS=$(GOOS) \
+		--build-arg GOARCH=$(GOARCH) \
+		--tag "${DOCKER_IMAGE}" .
 
 build:
 	@echo "==> Building RPM inside Docker container."
-	@docker run --rm --volume "$(shell pwd):$(DOCKER_VOLUME)" $(DOCKER_IMAGE) make -C $(DOCKER_VOLUME) rpm-build
+	@docker run --rm \
+		-e GOOS=$(GOOS) \
+		-e GOARCH=$(GOARCH) \
+		--volume "$(shell pwd):$(DOCKER_VOLUME)" \
+		$(DOCKER_IMAGE) make -C $(DOCKER_VOLUME) rpm-build
 
 rpm-build: rpm-clean
 	@echo "==> Downloading siegfried."
@@ -29,13 +46,13 @@ rpm-build: rpm-clean
 	cd $(SIEGFRIED_SRC)
 
 	@echo "==> Building sources."
-	go install -tags archivematica -v github.com/richardlehane/siegfried/cmd/sf@v$(VERSION)
-	go install -tags archivematica -v github.com/richardlehane/siegfried/cmd/roy@v$(VERSION)
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go install -tags archivematica -v github.com/richardlehane/siegfried/cmd/sf@v$(VERSION)
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go install -tags archivematica -v github.com/richardlehane/siegfried/cmd/roy@v$(VERSION)
 
 	@echo "==> Preparing environment for rpmbuild."
 	mkdir -p $(RPM_TOPDIR)/{BUILD,RPMS,SRPMS}
 	mkdir -p $(RPM_TOPDIR)/SOURCES/$(NAME)-$(VERSION)
-	cp -p /go/bin/* $(RPM_TOPDIR)/SOURCES/$(NAME)-$(VERSION)/
+	cp /go/bin/* $(RPM_TOPDIR)/SOURCES/$(NAME)-$(VERSION)/
 	tar czf $(RPM_TOPDIR)/SOURCES/$(NAME)-$(VERSION).tar.gz -C $(RPM_TOPDIR)/SOURCES $(NAME)-$(VERSION)
 	cp $(DOCKER_VOLUME)/package.spec $(RPM_TOPDIR)/package.spec
 
@@ -43,8 +60,8 @@ rpm-build: rpm-clean
 	rpmbuild $(RPMBUILD_ARGS) -ba --clean $(RPM_TOPDIR)/package.spec
 
 	@echo "==> Copying RPM files."
-	cp -p $(RPM_TOPDIR)/RPMS/x86_64/$(NAME)-$(VERSION)*.x86_64.rpm $(DOCKER_VOLUME)/
-	cp -p $(RPM_TOPDIR)/SRPMS/$(NAME)-$(VERSION)*.src.rpm $(DOCKER_VOLUME)/
+	cp $(RPM_TOPDIR)/RPMS/$(RPM_ARCH)/$(NAME)-$(VERSION)*.$(RPM_ARCH).rpm $(DOCKER_VOLUME)/
+	cp $(RPM_TOPDIR)/SRPMS/$(NAME)-$(VERSION)*.src.rpm $(DOCKER_VOLUME)/
 
 rpm-clean:
 	@echo "==> Cleaning up previous RPMs builds."

--- a/rpms/EL9/siegfried/Dockerfile
+++ b/rpms/EL9/siegfried/Dockerfile
@@ -1,13 +1,15 @@
 FROM rockylinux:9
 
-# Environmnet variables needed during build
-ENV GOVERSION 1.24.1
-ENV GOOS linux
-ENV GOARCH amd64
+ARG GOVERSION=1.24.1
+ARG GOOS=linux
+ARG GOARCH=amd64
 
 # Environment variables needed during runtime
-ENV GOPATH /go
-ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/go/bin
+ENV GOPATH=/go
+ENV PATH="/usr/local/go/bin:${PATH}"
+ENV GOVERSION=${GOVERSION}
+ENV GOOS=${GOOS}
+ENV GOARCH=${GOARCH}
 
 RUN yum -y install rpm-build make git && \
 	curl -sO https://storage.googleapis.com/golang/go${GOVERSION}.${GOOS}-${GOARCH}.tar.gz && \

--- a/rpms/EL9/siegfried/Makefile
+++ b/rpms/EL9/siegfried/Makefile
@@ -4,11 +4,21 @@ RPM_TOPDIR    = "/rpmbuild"
 DOCKER_VOLUME = "/src"
 DOCKER_IMAGE  = "rpmbuild-$(NAME)-$(VERSION)"
 SIEGFRIED_SRC = "/go/src/github.com/richardlehane/siegfried"
+GOOS          ?= linux
+GOARCH        ?= amd64
+
+RPM_ARCH = $(GOARCH)
+ifeq ($(GOARCH),amd64)
+  RPM_ARCH = x86_64
+else ifeq ($(GOARCH),arm64)
+  RPM_ARCH = aarch64
+endif
 
 RPMBUILD_ARGS := \
 	--define "_topdir $(RPM_TOPDIR)" \
 	--define "name $(NAME)" \
-	--define "version $(VERSION)"
+	--define "version $(VERSION)" \
+	--target "$(RPM_ARCH)"
 
 .PHONY: build-docker-image build rpm-build rpm-clean rpm-test
 
@@ -16,11 +26,18 @@ all: build-docker-image build
 
 build-docker-image:
 	@echo "==> Building Docker image with build environment."
-	@docker build --tag "${DOCKER_IMAGE}" .
+	@docker build \
+		--build-arg GOOS=$(GOOS) \
+		--build-arg GOARCH=$(GOARCH) \
+		--tag "${DOCKER_IMAGE}" .
 
 build:
 	@echo "==> Building RPM inside Docker container."
-	@docker run --rm --volume "$(shell pwd):$(DOCKER_VOLUME)" $(DOCKER_IMAGE) make -C $(DOCKER_VOLUME) rpm-build
+	@docker run --rm \
+		-e GOOS=$(GOOS) \
+		-e GOARCH=$(GOARCH) \
+		--volume "$(shell pwd):$(DOCKER_VOLUME)" \
+		$(DOCKER_IMAGE) make -C $(DOCKER_VOLUME) rpm-build
 
 rpm-build: rpm-clean
 	@echo "==> Downloading siegfried."
@@ -29,13 +46,13 @@ rpm-build: rpm-clean
 	cd $(SIEGFRIED_SRC)
 
 	@echo "==> Building sources."
-	go install -tags archivematica -v github.com/richardlehane/siegfried/cmd/sf@v$(VERSION)
-	go install -tags archivematica -v github.com/richardlehane/siegfried/cmd/roy@v$(VERSION)
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go install -tags archivematica -v github.com/richardlehane/siegfried/cmd/sf@v$(VERSION)
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go install -tags archivematica -v github.com/richardlehane/siegfried/cmd/roy@v$(VERSION)
 
 	@echo "==> Preparing environment for rpmbuild."
 	mkdir -p $(RPM_TOPDIR)/{BUILD,RPMS,SRPMS}
 	mkdir -p $(RPM_TOPDIR)/SOURCES/$(NAME)-$(VERSION)
-	cp -p /go/bin/* $(RPM_TOPDIR)/SOURCES/$(NAME)-$(VERSION)/
+	cp /go/bin/* $(RPM_TOPDIR)/SOURCES/$(NAME)-$(VERSION)/
 	tar czf $(RPM_TOPDIR)/SOURCES/$(NAME)-$(VERSION).tar.gz -C $(RPM_TOPDIR)/SOURCES $(NAME)-$(VERSION)
 	cp $(DOCKER_VOLUME)/package.spec $(RPM_TOPDIR)/package.spec
 
@@ -43,8 +60,8 @@ rpm-build: rpm-clean
 	rpmbuild $(RPMBUILD_ARGS) -ba --clean $(RPM_TOPDIR)/package.spec
 
 	@echo "==> Copying RPM files."
-	cp -p $(RPM_TOPDIR)/RPMS/x86_64/$(NAME)-$(VERSION)*.x86_64.rpm $(DOCKER_VOLUME)/
-	cp -p $(RPM_TOPDIR)/SRPMS/$(NAME)-$(VERSION)*.src.rpm $(DOCKER_VOLUME)/
+	cp $(RPM_TOPDIR)/RPMS/$(RPM_ARCH)/$(NAME)-$(VERSION)*.$(RPM_ARCH).rpm $(DOCKER_VOLUME)/
+	cp $(RPM_TOPDIR)/SRPMS/$(NAME)-$(VERSION)*.src.rpm $(DOCKER_VOLUME)/
 
 rpm-clean:
 	@echo "==> Cleaning up previous RPMs builds."


### PR DESCRIPTION
https://github.com/artefactual-labs/am-packbuild/pull/388 follow-up.

The same applies here: not suited for cross-compilation, but again I think that's ok for now since we can use arm64 CI builders if needed.