### PR TITLE
Fix AM Vagrant box publishing workflow

### DIFF
--- a/.github/workflows/vagrant-box-archivematica.yml
+++ b/.github/workflows/vagrant-box-archivematica.yml
@@ -107,9 +107,14 @@ jobs:
           ${{ github.workspace }}/archivematica-vagrant-${{ github.event.inputs.version }}.box
     - name: Provision a test VM with the new image
       run: |
+        sudo rm -rf "$VAGRANT_HOME"
+        sudo mkdir -p "$VAGRANT_HOME"
+        sudo chown "$USER:$USER" "$VAGRANT_HOME"
         vagrant init --minimal --no-tty archivematica-vagrant-${{ github.event.inputs.version }} file://${{ github.workspace }}/archivematica-vagrant-${{ github.event.inputs.version }}.box
         cat Vagrantfile
         vagrant up --debug-timestamp --provider virtualbox
+      env:
+        VAGRANT_HOME: "/mnt/vagrant"
     - name: Test AM is running in the test VM
       run: |
         sleep 180

--- a/.github/workflows/vagrant-box-archivematica.yml
+++ b/.github/workflows/vagrant-box-archivematica.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         ubuntu-version: [
-          "22.04",
+          "24.04",
         ]
     steps:
     - name: Check out code
@@ -56,7 +56,7 @@ jobs:
       fail-fast: false
       matrix:
         ubuntu-version: [
-          "22.04",
+          "24.04",
         ]
     permissions:
       contents: "read"

--- a/packer/templates/vagrant-box-archivematica/provisioning/group_vars/servers
+++ b/packer/templates/vagrant-box-archivematica/provisioning/group_vars/servers
@@ -23,8 +23,14 @@ archivematica_src_configure_am_email: "admin@example.com"
 archivematica_src_configure_am_api_key: "this_is_the_am_api_key"
 archivematica_src_configure_am_site_url: "http://127.0.0.1"
 
+archivematica_src_am_dashboard_environment:
+  ARCHIVEMATICA_DASHBOARD_DASHBOARD_SESSION_COOKIE_SECURE: "false"
+  ARCHIVEMATICA_DASHBOARD_DASHBOARD_CSRF_COOKIE_SECURE: "false"
+
 archivematica_src_ss_environment:
   SS_DB_URL: "mysql://{{ archivematica_src_ss_db_user }}:{{ archivematica_src_ss_db_password }}@{{ archivematica_src_ss_db_host }}:3306/{{ archivematica_src_ss_db_name }}"
+  SESSION_COOKIE_SECURE: "false"
+  CSRF_COOKIE_SECURE: "false"
 
 # percona role
 


### PR DESCRIPTION
This updates the Archivematica Vagrant box publishing workflow to:
* Use Ubuntu 24.04 as the base image
* Allow cookies to be sent through HTTP
* Use the disk space in the `/mnt` partition of the GitHub test runner VM to avoid the [error found](https://github.com/artefactual-labs/am-packbuild/actions/runs/18049260094) at the end of the release process:
  <img width="1020" height="222" alt="Captura desde 2025-09-29 16-46-54" src="https://github.com/user-attachments/assets/5e2e153c-8158-47ef-bd0f-d88f5e1d1464" />

This branch was used to publish the [1.18.0](https://portal.cloud.hashicorp.com/vagrant/discover/artefactual/archivematica/versions/1.18.0) Vagrant box [successfully](https://github.com/artefactual-labs/am-packbuild/actions/runs/18111203250).

