### PR TITLE
Fix test-ansible job in RPM packages test workflow

### DIFF
--- a/.github/workflows/test-am-rpms.yml
+++ b/.github/workflows/test-am-rpms.yml
@@ -279,6 +279,7 @@ jobs:
         export ANSIBLE_REMOTE_PORT=2222
         ansible-playbook -i localhost, EL9/ansible/playbook.yml \
             -u ubuntu \
+            -e "archivematica_src_rpm_repository_use_local_baseurl=${{ env.build_packages }}" \
             -v
     - name: Test AM API - Get processing configurations
       run: |

--- a/tests/archivematica/EL9/ansible/vars.yml
+++ b/tests/archivematica/EL9/ansible/vars.yml
@@ -36,9 +36,18 @@ archivematica_src_install_ss: "rpm"
 
 install_rpm_repositories: "true"
 
+archivematica_src_rpm_repository_local_baseurl: "file:///am-packbuild/rpms/EL9/_yum_repository/"
+archivematica_src_rpm_repository_public_baseurl: "https://packages.archivematica.org/1.18.x/rocky9"
+archivematica_src_rpm_repository_use_local_baseurl: true
+
+archivematica_src_rpm_repository_baseurl: >-
+  {{ archivematica_src_rpm_repository_local_baseurl
+     if archivematica_src_rpm_repository_use_local_baseurl | bool
+     else archivematica_src_rpm_repository_public_baseurl }}
+
 archivematica_src_rpm_repositories:
   archivematica:
-    baseurl: "file:///am-packbuild/rpms/EL9/_yum_repository/"
+    baseurl: "{{ archivematica_src_rpm_repository_baseurl }}"
     gpgcheck: 0
   archivematica-extras:
     baseurl: "https://packages.archivematica.org/1.18.x/rocky9-extras"


### PR DESCRIPTION
Previously, unchecking the `Build local packages` option had no effect because the playbook variables continued to reference the local `file:///` repository.

This update introduces explicit local and public base URLs in the test variables and propagates the workflow flag correctly, allowing Ansible to switch automatically to the public mirror when appropriate.

This is a workflow run with this branch and the `Build local packages` option unchecked now:

<img width="1050" height="432" alt="Captura desde 2025-10-31 17-07-00" src="https://github.com/user-attachments/assets/3f058189-5793-475d-a2b7-5c211eb5bd9b" />
