### PR TITLE
Drop Python 3.9 support in AM packages

### DIFF
--- a/debs/jammy/archivematica-storage-service/debian-storage-service/control
+++ b/debs/jammy/archivematica-storage-service/debian-storage-service/control
@@ -19,7 +19,7 @@ Build-Depends:
     pkg-config,
     zlib1g-dev
 Standards-Version: 3.9.8
-X-Python3-Version: >= 3.8
+X-Python3-Version: >= 3.10
 
 Package: archivematica-storage-service
 Architecture: amd64

--- a/debs/jammy/archivematica/debian-MCPClient/control
+++ b/debs/jammy/archivematica/debian-MCPClient/control
@@ -5,7 +5,7 @@ Maintainer: Artefactual Systems Inc. <sysadmin@artefactual.com>
 Build-Depends:
 	debhelper,
 Standards-Version: 3.9.8
-X-Python3-Version: >= 3.8
+X-Python3-Version: >= 3.10
 
 Package: archivematica-mcp-client
 Architecture: amd64

--- a/debs/jammy/archivematica/debian-MCPServer/control
+++ b/debs/jammy/archivematica/debian-MCPServer/control
@@ -5,7 +5,7 @@ Maintainer: Artefactual Systems Inc. <sysadmin@artefactual.com>
 Build-Depends:
 	debhelper,
 Standards-Version: 3.9.8
-X-Python3-Version: >= 3.8
+X-Python3-Version: >= 3.10
 
 Package: archivematica-mcp-server
 Architecture: amd64

--- a/debs/jammy/archivematica/debian-archivematica/control
+++ b/debs/jammy/archivematica/debian-archivematica/control
@@ -18,7 +18,7 @@ Build-Depends:
 	pkg-config,
 	rsync,
 Standards-Version: 3.9.8
-X-Python3-Version: >= 3.8
+X-Python3-Version: >= 3.10
 
 Package: archivematica
 Architecture: amd64

--- a/debs/jammy/archivematica/debian-archivematicaCommon/control
+++ b/debs/jammy/archivematica/debian-archivematicaCommon/control
@@ -5,7 +5,7 @@ Maintainer: Artefactual Systems Inc. <sysadmin@artefactual.com>
 Build-Depends:
 	debhelper
 Standards-Version: 3.9.8
-X-Python3-Version: >= 3.8
+X-Python3-Version: >= 3.10
 
 Package: archivematica-common
 Architecture: amd64

--- a/debs/jammy/archivematica/debian-dashboard/control
+++ b/debs/jammy/archivematica/debian-dashboard/control
@@ -5,7 +5,7 @@ Maintainer: Artefactual Systems Inc. <sysadmin@artefactual.com>
 Build-Depends:
 	debhelper,
 Standards-Version: 3.9.8
-X-Python3-Version: >= 3.8
+X-Python3-Version: >= 3.10
 
 Package: archivematica-dashboard
 Architecture: any

--- a/rpms/EL9/archivematica-storage-service/Dockerfile
+++ b/rpms/EL9/archivematica-storage-service/Dockerfile
@@ -32,6 +32,6 @@ RUN set -ex \
         openssl-devel \
         pkgconfig \
         postgresql-devel \
-        python3-devel \
+        python3.12-devel \
         python3-virtualenv \
     && yum clean all

--- a/rpms/EL9/archivematica-storage-service/package.spec
+++ b/rpms/EL9/archivematica-storage-service/package.spec
@@ -9,8 +9,8 @@ Summary: Archivematica Storage Service
 Group: Application/System
 License: AGPLv3
 Source0: %{git_repo}
-BuildRequires: git, gcc, libffi-devel, openssl-devel, libxslt-devel, python3-virtualenv, python3-devel, mariadb-devel, postgresql-devel, gcc-c++, openldap-devel, pkgconfig
-Requires: gnupg, libxslt-devel, policycoreutils-python-utils, python3-devel, rng-tools, rsync, nginx, unar, p7zip, shadow-utils, gettext
+BuildRequires: git, gcc, libffi-devel, openssl-devel, libxslt-devel, python3-virtualenv, python3.12-devel, mariadb-devel, postgresql-devel, gcc-c++, openldap-devel, pkgconfig
+Requires: gnupg, libxslt-devel, policycoreutils-python-utils, python3.12-devel, rng-tools, rsync, nginx, unar, p7zip, shadow-utils, gettext
 AutoReq: No
 AutoProv: No
 %description
@@ -63,7 +63,7 @@ mkdir -p /opt/archivematica/archivematica-storage-service
 cp -rf %{_sourcedir}/%{name}/. /opt/archivematica/archivematica-storage-service/
 cp -rf %{_sourcedir}/%{name}/. %{buildroot}/opt/archivematica/archivematica-storage-service/
 
-virtualenv /usr/share/archivematica/virtualenvs/archivematica-storage-service
+virtualenv --python=python3.12 /usr/share/archivematica/virtualenvs/archivematica-storage-service
 /usr/share/archivematica/virtualenvs/archivematica-storage-service/bin/pip install --upgrade pip setuptools
 /usr/share/archivematica/virtualenvs/archivematica-storage-service/bin/pip install -r %{_sourcedir}/%{name}/requirements.txt
 

--- a/rpms/EL9/archivematica/Dockerfile
+++ b/rpms/EL9/archivematica/Dockerfile
@@ -38,6 +38,6 @@ RUN set -ex \
         openssl-devel \
         pkgconfig \
         postgresql-devel \
-        python3-devel \
+        python3.12-devel \
         python3-virtualenv \
     && yum clean all

--- a/rpms/EL9/archivematica/archivematica.spec
+++ b/rpms/EL9/archivematica/archivematica.spec
@@ -12,8 +12,8 @@ Summary: Archivematica digital preservation system
 Group: Application/System
 License: AGPLv3
 Source0: %{git_repo}
-BuildRequires: git, gcc, openldap-devel, openssl-devel, python3-virtualenv, mariadb-devel, libxslt-devel, python3-devel, libffi-devel, gcc-c++, postgresql-devel, nodejs, pkgconfig
-Requires: python3-devel
+BuildRequires: git, gcc, openldap-devel, openssl-devel, python3-virtualenv, mariadb-devel, libxslt-devel, python3.12-devel, libffi-devel, gcc-c++, postgresql-devel, nodejs, pkgconfig
+Requires: python3.12-devel
 AutoReq: No
 AutoProv: No
 %description
@@ -164,7 +164,7 @@ cp -a %{_sourcedir}/%{name}/. /opt/archivematica/archivematica/
 cp -a %{_sourcedir}/%{name}/. %{buildroot}/opt/archivematica/archivematica/
 
 # Archivematica virtual environment
-virtualenv /usr/share/archivematica/virtualenvs/archivematica
+virtualenv --python=python3.12 /usr/share/archivematica/virtualenvs/archivematica
 /usr/share/archivematica/virtualenvs/archivematica/bin/pip install --upgrade pip setuptools
 /usr/share/archivematica/virtualenvs/archivematica/bin/pip install -r %{_sourcedir}/%{name}/requirements.txt
 


### PR DESCRIPTION
This sets Python 3.10 as the minimum supported version for the DEB packages and uses Python 3.12 to create the virtual environments for the RPM packages.

Connected to https://github.com/archivematica/Issues/issues/1760