### PR TITLE
Add tests for upgrading AM packages

### DIFF
--- a/.github/actions/setup-am-tests-venv/action.yml
+++ b/.github/actions/setup-am-tests-venv/action.yml
@@ -1,0 +1,46 @@
+name: "Setup Archivematica tests virtual environment"
+description: "Installs Python, provisions the Archivematica tests virtualenv, and adds it to PATH."
+inputs:
+  python-version:
+    description: "Python version to install"
+    required: false
+    default: "3.10"
+  requirements-file:
+    description: "Requirements filename relative to the working directory"
+    required: false
+    default: "requirements.txt"
+  working-directory:
+    description: "Directory where the virtualenv should be created"
+    required: false
+    default: "tests/archivematica"
+  venv-path:
+    description: "Virtualenv directory relative to the working directory"
+    required: false
+    default: ".venv"
+runs:
+  using: "composite"
+  steps:
+    - name: "Install Python"
+      uses: "actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548" # v6.1.0
+      with:
+        python-version: "${{ inputs.python-version }}"
+        cache: "pip"
+        cache-dependency-path: "${{ format('{0}/{1}', inputs.working-directory, inputs.requirements-file) }}"
+    - name: "Cache the virtual environment"
+      id: "venv-cache"
+      uses: "actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830" # v4.3.0
+      with:
+        path: "${{ inputs.working-directory }}/${{ inputs.venv-path }}/"
+        key: "os-${{ runner.os }}-python_version-${{ inputs.python-version }}-hash-${{ hashFiles(format('{0}/{1}', inputs.working-directory, inputs.requirements-file)) }}"
+    - name: "Set up the virtual environment"
+      if: "steps.venv-cache.outputs.cache-hit != 'true'"
+      shell: bash
+      working-directory: "${{ inputs.working-directory }}"
+      run: |
+        python3 -m venv "${{ inputs.venv-path }}"
+        "${{ inputs.venv-path }}/bin/python" -m pip install -r "${{ inputs.requirements-file }}"
+    - name: "Add virtual environment to PATH"
+      shell: bash
+      working-directory: "${{ inputs.working-directory }}"
+      run: |
+        echo "$PWD/${{ inputs.venv-path }}/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/test-am-debs.yml
+++ b/.github/workflows/test-am-debs.yml
@@ -125,30 +125,8 @@ jobs:
         wget https://github.com/containers/crun/releases/download/1.15/crun-1.15-linux-amd64
         sudo install crun-1.15-linux-amd64 /usr/bin/crun
         rm crun-1.15-linux-amd64
-    - name: "Install Python"
-      uses: "actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548" # v6.1.0
-      with:
-        python-version: "3.10"
-        cache: "pip"
-        cache-dependency-path: |
-          tests/archivematica/requirements.txt
-    - name: "Cache the virtual environment"
-      id: "venv-cache"
-      uses: "actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830" # v4.3.0
-      with:
-        path: |
-          tests/archivematica/.venv/
-        key: "os-${{ runner.os }}-python_version-${{ env.python_version }}-hash-${{ hashFiles('tests/archivematica/requirements.txt') }}"
-    - name: "Set up the virtual environment"
-      if: "steps.venv-cache.outputs.cache-hit == false"
-      working-directory: "${{ github.workspace }}/tests/archivematica"
-      run: |
-        python3 -m venv .venv
-        .venv/bin/python -m pip install -r requirements.txt
-    - name: "Add virtual environment to PATH"
-      working-directory: "${{ github.workspace }}/tests/archivematica"
-      run:
-        echo "$PWD/.venv/bin" >> $GITHUB_PATH
+    - name: "Prepare Archivematica test environment"
+      uses: ./.github/actions/setup-am-tests-venv
     - name: "Start the Compose environment"
       working-directory: "${{ github.workspace }}/tests/archivematica"
       env:

--- a/.github/workflows/test-am-rpms.yml
+++ b/.github/workflows/test-am-rpms.yml
@@ -125,30 +125,8 @@ jobs:
         wget https://github.com/containers/crun/releases/download/1.15/crun-1.15-linux-amd64
         sudo install crun-1.15-linux-amd64 /usr/bin/crun
         rm crun-1.15-linux-amd64
-    - name: "Install Python"
-      uses: "actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548" # v6.1.0
-      with:
-        python-version: "3.10"
-        cache: "pip"
-        cache-dependency-path: |
-          tests/archivematica/requirements.txt
-    - name: "Cache the virtual environment"
-      id: "venv-cache"
-      uses: "actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830" # v4.3.0
-      with:
-        path: |
-          tests/archivematica/.venv/
-        key: "os-${{ runner.os }}-python_version-${{ env.python_version }}-hash-${{ hashFiles('tests/archivematica/requirements.txt') }}"
-    - name: "Set up the virtual environment"
-      if: "steps.venv-cache.outputs.cache-hit == false"
-      working-directory: "${{ github.workspace }}/tests/archivematica"
-      run: |
-        python3 -m venv .venv
-        .venv/bin/python -m pip install -r requirements.txt
-    - name: "Add virtual environment to PATH"
-      working-directory: "${{ github.workspace }}/tests/archivematica"
-      run:
-        echo "$PWD/.venv/bin" >> $GITHUB_PATH
+    - name: "Prepare Archivematica test environment"
+      uses: ./.github/actions/setup-am-tests-venv
     - name: "Start the Compose environment"
       working-directory: "${{ github.workspace }}/tests/archivematica"
       env:
@@ -236,30 +214,8 @@ jobs:
         wget https://github.com/containers/crun/releases/download/1.15/crun-1.15-linux-amd64
         sudo install crun-1.15-linux-amd64 /usr/bin/crun
         rm crun-1.15-linux-amd64
-    - name: "Install Python"
-      uses: "actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548" # v6.1.0
-      with:
-        python-version: "3.10"
-        cache: "pip"
-        cache-dependency-path: |
-          tests/archivematica/requirements.txt
-    - name: "Cache the virtual environment"
-      id: "venv-cache"
-      uses: "actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830" # v4.3.0
-      with:
-        path: |
-          tests/archivematica/.venv/
-        key: "os-${{ runner.os }}-python_version-${{ env.python_version }}-hash-${{ hashFiles('tests/archivematica/requirements.txt') }}"
-    - name: "Set up the virtual environment"
-      if: "steps.venv-cache.outputs.cache-hit == false"
-      working-directory: "${{ github.workspace }}/tests/archivematica"
-      run: |
-        python3 -m venv .venv
-        .venv/bin/python -m pip install -r requirements.txt
-    - name: "Add virtual environment to PATH"
-      working-directory: "${{ github.workspace }}/tests/archivematica"
-      run:
-        echo "$PWD/.venv/bin" >> $GITHUB_PATH
+    - name: "Prepare Archivematica test environment"
+      uses: ./.github/actions/setup-am-tests-venv
     - name: "Start the Compose environment"
       working-directory: "${{ github.workspace }}/tests/archivematica"
       env:

--- a/.github/workflows/test-am-upgrade-debs.yml
+++ b/.github/workflows/test-am-upgrade-debs.yml
@@ -1,0 +1,267 @@
+name: Archivematica DEB Packages Upgrade Test
+on:
+  workflow_dispatch:
+    inputs:
+      baseline_archivematica_packages_repo_version:
+        description: "Archivematica packages repository version to install before the upgrade (e.g. 1.17.x)"
+        required: false
+        default: "1.17.x"
+        type: "string"
+      baseline_elasticsearch_repo_version:
+        description: "Elasticsearch repository version for the baseline install (e.g. 6.x)"
+        required: false
+        default: "6.x"
+        type: "string"
+      upgrade_archivematica_packages_repo_version:
+        description: "Archivematica packages repository version to upgrade to (e.g. 1.18.x)"
+        required: false
+        default: "1.18.x"
+        type: "string"
+      upgrade_elasticsearch_repo_version:
+        description: "Elasticsearch repository version for the upgraded system (e.g. 8.x)"
+        required: false
+        default: "8.x"
+        type: "string"
+      build_packages:
+        description: "Build local packages for the upgrade target"
+        required: true
+        default: true
+        type: "boolean"
+  pull_request:
+    paths:
+      - "debs/jammy/archivematica/**"
+      - "debs/jammy/archivematica-storage-service/**"
+      - "tests/archivematica/**"
+      - "!tests/archivematica/README.md"
+      - "!tests/archivematica/EL9/**"
+  push:
+    branches:
+      - "stable/**"
+      - "qa/**"
+    paths:
+      - "debs/jammy/archivematica/**"
+      - "debs/jammy/archivematica-storage-service/**"
+      - "tests/archivematica/**"
+      - "!tests/archivematica/README.md"
+      - "!tests/archivematica/EL9/**"
+  schedule:
+    - cron: "0 4 * * *"
+
+env:
+  BASELINE_ARCHIVEMATICA_PACKAGES_REPO_VERSION: ${{ inputs.baseline_archivematica_packages_repo_version || '1.17.x' }}
+  BASELINE_ELASTICSEARCH_PACKAGES_REPO_VERSION: ${{ inputs.baseline_elasticsearch_repo_version || '6.x' }}
+  UPGRADE_ARCHIVEMATICA_PACKAGES_REPO_VERSION: ${{ inputs.upgrade_archivematica_packages_repo_version || '1.18.x' }}
+  UPGRADE_ELASTICSEARCH_PACKAGES_REPO_VERSION: ${{ inputs.upgrade_elasticsearch_repo_version || '8.x' }}
+
+jobs:
+  build-am-packages:
+    name: Build Archivematica packages
+    runs-on: ubuntu-latest
+    if: "${{ github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.build_packages) }}"
+    steps:
+    - name: Check out code
+      uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+    - name: Build
+      run: |
+        make -C ${{ github.workspace }}/debs/jammy/archivematica
+    - name: Save artifacts
+      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+      with:
+        name: archivematica-packages
+        path: |
+          ${{ github.workspace }}/debs/jammy/archivematica/repo
+  build-ss-packages:
+    name: Build Storage Service packages
+    runs-on: ubuntu-latest
+    if: "${{ github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.build_packages) }}"
+    steps:
+    - name: Check out code
+      uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+    - name: Build
+      run: |
+        make -C ${{ github.workspace }}/debs/jammy/archivematica-storage-service
+    - name: Save artifacts
+      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+      with:
+        name: archivematica-storage-service-packages
+        path: |
+          ${{ github.workspace }}/debs/jammy/archivematica-storage-service/repo
+  create-package-repo:
+    name: Create package repository
+    runs-on: ubuntu-latest
+    if: "${{ github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.build_packages) }}"
+    needs:
+    - build-am-packages
+    - build-ss-packages
+    steps:
+    - name: Check out code
+      uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+    - name: Restore Archivematica packages
+      uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+      with:
+        name: archivematica-packages
+        path: |
+          ${{ github.workspace }}/debs/jammy/archivematica/repo
+    - name: Restore Storage Service packages
+      uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+      with:
+        name: archivematica-storage-service-packages
+        path: |
+          ${{ github.workspace }}/debs/jammy/archivematica-storage-service/repo
+    - name: Create repository
+      run: |
+        make -C ${{ github.workspace }}/debs/jammy createrepo
+    - name: Save package repository
+      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+      with:
+        name: package-repository
+        path: |
+          ${{ github.workspace }}/debs/jammy/_deb_repository
+  test-upgrade:
+    name: Test upgrade path
+    needs: create-package-repo
+    runs-on: ubuntu-22.04
+    if: >-
+      ${{
+        always() && (
+          needs.create-package-repo.result == 'success' ||
+          (github.event_name == 'workflow_dispatch' && inputs.build_packages == false)
+        )
+      }}
+    env:
+      build_packages: "${{ github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.build_packages) }}"
+      python_version: "3.10"
+    steps:
+    - name: Check out code
+      uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+    - name: Restore package repository
+      if: ${{ env.build_packages == 'true' && needs.create-package-repo.result == 'success' }}
+      uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+      with:
+        name: package-repository
+        path: ${{ github.workspace }}/debs/jammy/_deb_repository
+    - name: "Upgrade crun (supports Ubuntu's systemd in the Dockerfile)"
+      run: |
+        wget https://github.com/containers/crun/releases/download/1.15/crun-1.15-linux-amd64
+        sudo install crun-1.15-linux-amd64 /usr/bin/crun
+        rm crun-1.15-linux-amd64
+    - name: "Prepare Archivematica test environment"
+      uses: ./.github/actions/setup-am-tests-venv
+      with:
+        python-version: "${{ env.python_version }}"
+        working-directory: "tests/archivematica"
+    - name: "Start the Compose environment"
+      working-directory: "${{ github.workspace }}/tests/archivematica"
+      env:
+        DOCKER_IMAGE_NAME: "ubuntu"
+        DOCKER_IMAGE_TAG: "22.04"
+      run: |
+        podman-compose up --detach
+    - name: "Install baseline packages"
+      working-directory: ${{ github.workspace }}/tests/archivematica
+      run: |
+        podman-compose exec \
+          --env LOCAL_REPOSITORY="false" \
+          --env ARCHIVEMATICA_PACKAGES_REPO_VERSION="${{ env.BASELINE_ARCHIVEMATICA_PACKAGES_REPO_VERSION }}" \
+          --env ELASTICSEARCH_PACKAGES_REPO_VERSION="${{ env.BASELINE_ELASTICSEARCH_PACKAGES_REPO_VERSION }}" \
+          --user ubuntu \
+          archivematica \
+          /am-packbuild/tests/archivematica/jammy/install.sh
+    - name: "Get baseline Archivematica version"
+      run: |
+        curl \
+          --silent \
+          --dump-header - \
+          --header 'Authorization: ApiKey admin:apikey' \
+          --header 'Content-Type: application/json' \
+          'http://localhost:8000/api/processing-configuration/' | grep X-Archivematica-Version
+    - name: Test baseline AM API - Get processing configurations
+      run: |
+        test $( \
+            curl \
+                --silent \
+                --header 'Authorization: ApiKey admin:apikey' \
+                --header 'Content-Type: application/json' \
+                'http://localhost:8000/api/processing-configuration/' \
+            | jq -r '.processing_configurations == ["automated", "default"]' \
+        ) == true
+    - name: Test baseline SS API - Get pipeline count
+      run: |
+        test $( \
+            curl \
+                --silent \
+                --header 'Authorization: ApiKey admin:apikey' \
+                --header 'Content-Type: application/json' \
+                'http://localhost:8001/api/v2/pipeline/' \
+            | jq -r '.meta.total_count == 1' \
+        ) == true
+    - name: "Upgrade packages"
+      working-directory: ${{ github.workspace }}/tests/archivematica
+      run: |
+        podman-compose exec \
+          --env LOCAL_REPOSITORY="${{ env.build_packages }}" \
+          --env ARCHIVEMATICA_PACKAGES_REPO_VERSION="${{ env.UPGRADE_ARCHIVEMATICA_PACKAGES_REPO_VERSION }}" \
+          --env ELASTICSEARCH_PACKAGES_REPO_VERSION="${{ env.UPGRADE_ELASTICSEARCH_PACKAGES_REPO_VERSION }}" \
+          --user ubuntu \
+          archivematica \
+          /am-packbuild/tests/archivematica/jammy/upgrade.sh
+    - name: "Get upgraded Archivematica version"
+      run: |
+        curl \
+          --silent \
+          --dump-header - \
+          --header 'Authorization: ApiKey admin:apikey' \
+          --header 'Content-Type: application/json' \
+          'http://localhost:8000/api/processing-configuration/' | grep X-Archivematica-Version
+    - name: Test AM API - Get processing configurations
+      run: |
+        test $( \
+            curl \
+                --silent \
+                --header 'Authorization: ApiKey admin:apikey' \
+                --header 'Content-Type: application/json' \
+                'http://localhost:8000/api/processing-configuration/' \
+            | jq -r '.processing_configurations == ["automated", "default"]' \
+        ) == true
+    - name: Test SS API - Get pipeline count
+      run: |
+        test $( \
+            curl \
+                --silent \
+                --header 'Authorization: ApiKey admin:apikey' \
+                --header 'Content-Type: application/json' \
+                'http://localhost:8001/api/v2/pipeline/' \
+            | jq -r '.meta.total_count == 1' \
+        ) == true
+    - name: "Save common logs on failure"
+      if: "${{ failure() }}"
+      working-directory: "${{ github.workspace }}/tests/archivematica"
+      run: |
+        podman-compose exec --user root archivematica mkdir -p /tmp/logs/journalctl
+        podman-compose exec --user root archivematica bash -c 'journalctl -u archivematica-mcp-client --no-pager > /tmp/logs/journalctl/archivematica-mcp-client'
+    - name: "Save logs on failure"
+      if: "${{ failure() }}"
+      working-directory: "${{ github.workspace }}/tests/archivematica"
+      run: |
+        podman-compose exec --user root archivematica bash -c '
+          set -euo pipefail
+          mkdir -p /tmp/logs
+          for path in /var/log/archivematica /var/log/mysql /var/log/elasticsearch /var/log/gearman-job-server /var/log/clamav /var/log/nginx; do
+            if [ -e "$path" ]; then
+              cp -r "$path" /tmp/logs/
+            else
+              echo "Skipping missing log path: $path"
+            fi
+          done
+        '
+    - name: "Copy logs from VM"
+      if: "${{ failure() }}"
+      working-directory: "${{ github.workspace }}/tests/archivematica"
+      run: |
+        podman cp archivematica-package-testing_archivematica_1:/tmp/logs/ .
+    - name: "Upload logs on failure"
+      if: "${{ failure() }}"
+      uses: "actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4" # v5.0.0
+      with:
+        name: "logs-test-upgrade-ubuntu"
+        path: "${{ github.workspace }}/tests/archivematica/logs"

--- a/.github/workflows/test-am-upgrade-rpms.yml
+++ b/.github/workflows/test-am-upgrade-rpms.yml
@@ -1,0 +1,269 @@
+name: Archivematica RPM Packages Upgrade Test
+on:
+  workflow_dispatch:
+    inputs:
+      baseline_archivematica_packages_repo_version:
+        description: "Archivematica packages repository version to install before the upgrade (e.g. 1.17.x)"
+        required: false
+        default: "1.17.x"
+        type: "string"
+      baseline_elasticsearch_repo_version:
+        description: "Elasticsearch repository version for the baseline install (e.g. 6.x)"
+        required: false
+        default: "6.x"
+        type: "string"
+      upgrade_archivematica_packages_repo_version:
+        description: "Archivematica packages repository version to upgrade to (e.g. 1.18.x)"
+        required: false
+        default: "1.18.x"
+        type: "string"
+      upgrade_elasticsearch_repo_version:
+        description: "Elasticsearch repository version for the upgraded system (e.g. 8.x)"
+        required: false
+        default: "8.x"
+        type: "string"
+      build_packages:
+        description: "Build local packages for the upgrade target"
+        required: true
+        default: true
+        type: "boolean"
+  pull_request:
+    paths:
+      - "rpms/EL9/archivematica/**"
+      - "rpms/EL9/archivematica-storage-service/**"
+      - "tests/archivematica/**"
+      - "!tests/archivematica/README.md"
+      - "!tests/archivematica/jammy/**"
+  push:
+    branches:
+      - "stable/**"
+      - "qa/**"
+    paths:
+      - "rpms/EL9/archivematica/**"
+      - "rpms/EL9/archivematica-storage-service/**"
+      - "tests/archivematica/**"
+      - "!tests/archivematica/README.md"
+      - "!tests/archivematica/jammy/**"
+  schedule:
+    - cron: "0 5 * * *"
+
+env:
+  BASELINE_ARCHIVEMATICA_PACKAGES_REPO_VERSION: ${{ inputs.baseline_archivematica_packages_repo_version || '1.17.x' }}
+  BASELINE_ELASTICSEARCH_PACKAGES_REPO_VERSION: ${{ inputs.baseline_elasticsearch_repo_version || '6.x' }}
+  UPGRADE_ARCHIVEMATICA_PACKAGES_REPO_VERSION: ${{ inputs.upgrade_archivematica_packages_repo_version || '1.18.x' }}
+  UPGRADE_ELASTICSEARCH_PACKAGES_REPO_VERSION: ${{ inputs.upgrade_elasticsearch_repo_version || '8.x' }}
+
+jobs:
+  build-am-packages:
+    name: Build Archivematica packages
+    runs-on: ubuntu-latest
+    if: "${{ github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.build_packages) }}"
+    steps:
+    - name: Check out code
+      uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+    - name: Build
+      run: |
+        make -C ${{ github.workspace }}/rpms/EL9/archivematica
+    - name: Save artifacts
+      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+      with:
+        name: archivematica-packages
+        path: |
+          ${{ github.workspace }}/rpms/EL9/archivematica/*.rpm
+  build-ss-packages:
+    name: Build Storage Service packages
+    runs-on: ubuntu-latest
+    if: "${{ github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.build_packages) }}"
+    steps:
+    - name: Check out code
+      uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+    - name: Build
+      run: |
+        make -C ${{ github.workspace }}/rpms/EL9/archivematica-storage-service
+    - name: Save artifacts
+      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+      with:
+        name: archivematica-storage-service-packages
+        path: |
+          ${{ github.workspace }}/rpms/EL9/archivematica-storage-service/*.rpm
+  create-package-repo:
+    name: Create package repository
+    runs-on: ubuntu-latest
+    if: "${{ github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.build_packages) }}"
+    needs:
+    - build-am-packages
+    - build-ss-packages
+    steps:
+    - name: Check out code
+      uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+    - name: Restore Archivematica packages
+      uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+      with:
+        name: archivematica-packages
+        path: |
+          ${{ github.workspace }}/rpms/EL9/archivematica/
+    - name: Restore Storage Service packages
+      uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+      with:
+        name: archivematica-storage-service-packages
+        path: |
+          ${{ github.workspace }}/rpms/EL9/archivematica-storage-service
+    - name: Create repository
+      run: |
+        make -C ${{ github.workspace }}/rpms/EL9 createrepo
+    - name: Save package repository
+      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+      with:
+        name: package-repository
+        path: |
+          ${{ github.workspace }}/rpms/EL9/_yum_repository
+  test-upgrade:
+    name: Test upgrade path
+    needs: create-package-repo
+    runs-on: ubuntu-22.04
+    if: >-
+      ${{
+        always() && (
+          needs.create-package-repo.result == 'success' ||
+          (github.event_name == 'workflow_dispatch' && inputs.build_packages == false)
+        )
+      }}
+    env:
+      build_packages: "${{ github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.build_packages) }}"
+      python_version: "3.10"
+    steps:
+    - name: Check out code
+      uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+    - name: Restore package repository
+      if: ${{ env.build_packages == 'true' && needs.create-package-repo.result == 'success' }}
+      uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+      with:
+        name: package-repository
+        path: ${{ github.workspace }}/rpms/EL9/_yum_repository
+    - name: "Upgrade crun (supports Ubuntu's systemd in the Dockerfile)"
+      run: |
+        wget https://github.com/containers/crun/releases/download/1.15/crun-1.15-linux-amd64
+        sudo install crun-1.15-linux-amd64 /usr/bin/crun
+        rm crun-1.15-linux-amd64
+    - name: "Prepare Archivematica test environment"
+      uses: ./.github/actions/setup-am-tests-venv
+      with:
+        python-version: "${{ env.python_version }}"
+        working-directory: "tests/archivematica"
+    - name: "Start the Compose environment"
+      working-directory: "${{ github.workspace }}/tests/archivematica"
+      env:
+        DOCKER_IMAGE_NAME: "rockylinux"
+        DOCKER_IMAGE_TAG: "9"
+      run: |
+        podman-compose up --detach
+    - name: "Install baseline packages"
+      working-directory: ${{ github.workspace }}/tests/archivematica
+      run: |
+        podman-compose exec \
+          --env LOCAL_REPOSITORY="false" \
+          --env ARCHIVEMATICA_PACKAGES_REPO_VERSION="${{ env.BASELINE_ARCHIVEMATICA_PACKAGES_REPO_VERSION }}" \
+          --env ELASTICSEARCH_PACKAGES_REPO_VERSION="${{ env.BASELINE_ELASTICSEARCH_PACKAGES_REPO_VERSION }}" \
+          --user ubuntu \
+          archivematica \
+          /am-packbuild/tests/archivematica/EL9/install.sh
+    - name: "Get baseline Archivematica version"
+      run: |
+        curl \
+          --silent \
+          --dump-header - \
+          --header 'Authorization: ApiKey admin:apikey' \
+          --header 'Content-Type: application/json' \
+          'http://localhost:8000/api/processing-configuration/' | grep X-Archivematica-Version
+    - name: Test baseline AM API - Get processing configurations
+      run: |
+        test $( \
+            curl \
+                --silent \
+                --header 'Authorization: ApiKey admin:apikey' \
+                --header 'Content-Type: application/json' \
+                'http://localhost:8000/api/processing-configuration/' \
+            | jq -r '.processing_configurations == ["automated", "default"]' \
+        ) == true
+    - name: Test baseline SS API - Get pipeline count
+      run: |
+        test $( \
+            curl \
+                --silent \
+                --header 'Authorization: ApiKey admin:apikey' \
+                --header 'Content-Type: application/json' \
+                'http://localhost:8001/api/v2/pipeline/' \
+            | jq -r '.meta.total_count == 1' \
+        ) == true
+    - name: "Upgrade packages"
+      working-directory: ${{ github.workspace }}/tests/archivematica
+      run: |
+        podman-compose exec \
+          --env LOCAL_REPOSITORY="${{ env.build_packages }}" \
+          --env ARCHIVEMATICA_PACKAGES_REPO_VERSION="${{ env.UPGRADE_ARCHIVEMATICA_PACKAGES_REPO_VERSION }}" \
+          --env ELASTICSEARCH_PACKAGES_REPO_VERSION="${{ env.UPGRADE_ELASTICSEARCH_PACKAGES_REPO_VERSION }}" \
+          --user ubuntu \
+          archivematica \
+          /am-packbuild/tests/archivematica/EL9/upgrade.sh
+    - name: "Get upgraded Archivematica version"
+      run: |
+        curl \
+          --silent \
+          --dump-header - \
+          --header 'Authorization: ApiKey admin:apikey' \
+          --header 'Content-Type: application/json' \
+          'http://localhost:8000/api/processing-configuration/' | grep X-Archivematica-Version
+    - name: Test AM API - Get processing configurations
+      run: |
+        test $( \
+            curl \
+                --silent \
+                --header 'Authorization: ApiKey admin:apikey' \
+                --header 'Content-Type: application/json' \
+                'http://localhost:8000/api/processing-configuration/' \
+            | jq -r '.processing_configurations == ["automated", "default"]' \
+        ) == true
+    - name: Test SS API - Get pipeline count
+      run: |
+        test $( \
+            curl \
+                --silent \
+                --header 'Authorization: ApiKey admin:apikey' \
+                --header 'Content-Type: application/json' \
+                'http://localhost:8001/api/v2/pipeline/' \
+            | jq -r '.meta.total_count == 1' \
+        ) == true
+    - name: "Save common logs on failure"
+      if: ${{ failure() }}
+      working-directory: "${{ github.workspace }}/tests/archivematica"
+      run: |
+        podman-compose exec --user root archivematica mkdir -p /tmp/logs/journalctl
+        podman-compose exec --user root archivematica bash -c 'journalctl -u archivematica-mcp-client --no-pager > /tmp/logs/journalctl/archivematica-mcp-client'
+    - name: "Save logs on failure"
+      if: ${{ failure() }}
+      working-directory: "${{ github.workspace }}/tests/archivematica"
+      run: |
+        podman-compose exec --user root archivematica bash -c 'journalctl -u mysqld --no-pager > /tmp/logs/journalctl/mysql'
+        podman-compose exec --user root archivematica bash -c 'journalctl -u clamd@scan --no-pager > /tmp/logs/journalctl/clamd'
+        podman-compose exec --user root archivematica bash -c '
+          set -euo pipefail
+          mkdir -p /tmp/logs
+          for path in /var/log/archivematica /var/log/mysqld.log /var/log/mysql /var/log/elasticsearch /var/log/nginx; do
+            if [ -e "$path" ]; then
+              cp -r "$path" /tmp/logs/
+            else
+              echo "Skipping missing log path: $path"
+            fi
+          done
+        '
+    - name: "Copy logs from VM"
+      if: ${{ failure() }}
+      working-directory: "${{ github.workspace }}/tests/archivematica"
+      run: |
+        podman cp archivematica-package-testing_archivematica_1:/tmp/logs/ .
+    - name: "Upload logs on failure"
+      if: ${{ failure() }}
+      uses: "actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4" # v5.0.0
+      with:
+        name: "logs-test-upgrade"
+        path: "${{ github.workspace }}/tests/archivematica/logs"

--- a/tests/archivematica/EL9/install.sh
+++ b/tests/archivematica/EL9/install.sh
@@ -38,8 +38,12 @@ sudo -u root yum-config-manager --enable crb
 #
 
 if [ "$(getenforce)" != "Disabled" ]; then
-    sudo semanage port -m -t http_port_t -p tcp 80
-    sudo semanage port -a -t http_port_t -p tcp 8000
+    if ! sudo semanage port -m -t http_port_t -p tcp 80; then
+        sudo semanage port -a -t http_port_t -p tcp 80
+    fi
+    if ! sudo semanage port -m -t http_port_t -p tcp 8000; then
+        sudo semanage port -a -t http_port_t -p tcp 8000
+    fi
     sudo setsebool -P httpd_can_network_connect_db=1
     sudo setsebool -P httpd_can_network_connect=1
     sudo setsebool -P httpd_setrlimit 1
@@ -66,6 +70,7 @@ fi
 #
 
 sudo -H -u root mysql -hlocalhost -uroot -e "DROP DATABASE IF EXISTS SS; CREATE DATABASE SS CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;"
+sudo -H -u root mysql -hlocalhost -uroot -e "DROP USER IF EXISTS 'archivematica'@'localhost';"
 sudo -H -u root mysql -hlocalhost -uroot -e "CREATE USER 'archivematica'@'localhost' IDENTIFIED BY 'demo';"
 sudo -H -u root mysql -hlocalhost -uroot -e "GRANT ALL ON SS.* TO 'archivematica'@'localhost';"
 
@@ -92,7 +97,9 @@ sudo -H -u root mysql -hlocalhost -uroot -e "GRANT ALL ON MCP.* TO 'archivematic
 
 run_archivematica_manage dashboard migrate --noinput
 
-set_search_env_flags "/etc/sysconfig" "${search_enabled}" "dashboard" "mcp-server"
+if [ "${search_enabled}" != "true" ] ; then
+    set_search_env_flags "/etc/sysconfig" "${search_enabled}" "dashboard" "mcp-server"
+fi
 
 sudo -u root systemctl enable archivematica-mcp-server
 sudo -u root systemctl start archivematica-mcp-server
@@ -113,7 +120,9 @@ sudo -u root yum install -y archivematica-mcp-client
 sudo -u root sed -i 's/^#TCPSocket/TCPSocket/g' /etc/clamd.d/scan.conf
 sudo -u root sed -i 's/^Example//g' /etc/clamd.d/scan.conf
 
-set_search_env_flags "/etc/sysconfig" "${search_enabled}" "mcp-client"
+if [ "${search_enabled}" != "true" ] ; then
+    set_search_env_flags "/etc/sysconfig" "${search_enabled}" "mcp-client"
+fi
 
 sudo -u root systemctl enable archivematica-mcp-client
 sudo -u root systemctl start archivematica-mcp-client
@@ -154,8 +163,28 @@ run_archivematica_manage dashboard install \
     --ss-api-key="apikey" \
     --site-url="http://localhost"
 
+if ! dashboard_code_dir=$(
+    first_existing_dir \
+        /opt/archivematica/archivematica \
+        /usr/share/archivematica/dashboard \
+        /usr/lib/archivematica/dashboard
+); then
+    echo "Unable to locate dashboard source directory" >&2
+    exit 1
+fi
+
 run_archivematica_manage dashboard collectstatic --noinput --clear
-run_archivematica_manage dashboard --chdir /opt/archivematica/archivematica/ compilemessages
+run_archivematica_manage dashboard --chdir "${dashboard_code_dir}" compilemessages
+
+if ! storage_service_code_dir=$(
+    first_existing_dir \
+        /opt/archivematica/archivematica-storage-service \
+        /usr/share/archivematica/storage-service \
+        /usr/lib/archivematica/storage-service
+); then
+    echo "Unable to locate storage service source directory" >&2
+    exit 1
+fi
 
 run_archivematica_manage storage-service collectstatic --noinput --clear
-run_archivematica_manage storage-service --chdir /opt/archivematica/archivematica-storage-service/ compilemessages
+run_archivematica_manage storage-service --chdir "${storage_service_code_dir}" compilemessages

--- a/tests/archivematica/EL9/upgrade.sh
+++ b/tests/archivematica/EL9/upgrade.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -x
+
+THIS_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=tests/archivematica/common/helpers.sh
+source "${THIS_DIR}/../common/helpers.sh"
+# shellcheck source=tests/archivematica/common/elasticsearch.sh
+source "${THIS_DIR}/../common/elasticsearch.sh"
+
+trap cleanup_temp_elasticsearch6 EXIT
+
+local_repository=$(get_env_boolean "LOCAL_REPOSITORY" "false")
+packages_repo_version="${ARCHIVEMATICA_PACKAGES_REPO_VERSION:-1.18.x}"
+elasticsearch_repo_version="${ELASTICSEARCH_PACKAGES_REPO_VERSION:-8.x}"
+elasticsearch_package_version="${ELASTICSEARCH_PACKAGE_VERSION:-}"
+
+dump_lowercase_environment_variables
+echo "Using Archivematica packages repository version: ${packages_repo_version}"
+echo "Using Elasticsearch packages repository version: ${elasticsearch_repo_version}"
+if [ -n "${elasticsearch_package_version}" ]; then
+    echo "Using Elasticsearch package version: ${elasticsearch_package_version}"
+fi
+
+# Stop Archivematica services.
+stop_archivematica_services
+
+# Back up Elasticsearch data.
+sudo -u root systemctl stop elasticsearch
+sudo -u root tar --create --gzip --file "/root/var_lib_elasticsearch_$(date +%y%m%d).tgz" /var/lib/elasticsearch
+
+# Set up temporary Elasticsearch 6.x instance.
+sudo -u root yum install -y java-11-openjdk java-11-openjdk-devel
+
+# Set up Elasticsearch 6.x.
+setup_temp_elasticsearch6
+
+# Back up Elasticsearch 6.x directories.
+sudo -u root cp -a /etc/elasticsearch /etc/elasticsearch-6
+sudo -u root cp -a /var/lib/elasticsearch /var/lib/elasticsearch-6
+sudo -u root cp -a /var/log/elasticsearch /var/log/elasticsearch-6
+
+# Remove Elasticsearch 6.x.
+sudo -u root yum remove -y elasticsearch
+sudo -u root rm -rf /var/lib/elasticsearch /var/log/elasticsearch /etc/elasticsearch
+
+# Install Elasticsearch 8.x.
+install_elasticsearch_rpm "${elasticsearch_repo_version}" "${elasticsearch_package_version}"
+
+sudo -u root systemctl restart elasticsearch
+wait_for_elasticsearch "http://localhost:9200"
+
+#
+# Configure repository
+#
+
+configure_archivematica_yum_repos "${local_repository}" "${packages_repo_version}"
+
+sudo -u root yum update -y
+
+run_archivematica_manage storage-service migrate
+run_archivematica_manage dashboard migrate --noinput
+
+restart_archivematica_services
+
+# Reindex Elasticsearch data.
+reindex_elasticsearch_data
+
+# Delete temporary Elasticsearch 6.x instance.
+cleanup_temp_elasticsearch6
+trap - EXIT

--- a/tests/archivematica/README.md
+++ b/tests/archivematica/README.md
@@ -10,10 +10,14 @@
 - [Set up EL9 packages](#set-up-el9-packages)
   - [Install EL9 packages from archivematica.org](#install-el9-packages-from-archivematicaorg)
   - [Install EL9 packages from a local repository](#install-el9-packages-from-a-local-repository)
+  - [Upgrade EL9 packages from archivematica.org](#upgrade-el9-packages-from-archivematicaorg)
+  - [Upgrade EL9 packages from a local repository](#upgrade-el9-packages-from-a-local-repository)
   - [Install EL9 packages with Ansible](#install-el9-packages-with-ansible)
 - [Set up Ubuntu 22.04 Jammy packages](#set-up-ubuntu-2204-jammy-packages)
   - [Install jammy packages from archivematica.org](#install-jammy-packages-from-archivematicaorg)
   - [Install jammy packages from a local repository](#install-jammy-packages-from-a-local-repository)
+  - [Upgrade jammy packages from archivematica.org](#upgrade-jammy-packages-from-archivematicaorg)
+  - [Upgrade jammy packages from a local repository](#upgrade-jammy-packages-from-a-local-repository)
 - [Test the Archivematica installation](#test-the-archivematica-installation)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -80,6 +84,51 @@ Install `EL9` packages using the local repository:
 
 ```shell
 podman-compose exec --env LOCAL_REPOSITORY="yes" --user ubuntu archivematica /am-packbuild/tests/archivematica/EL9/install.sh
+```
+
+### Upgrade EL9 packages from archivematica.org
+
+Keep the same running container for both steps: install the release you want to
+upgrade _from_, then execute the upgrade script pointing at the release you
+want to validate. Swap the version numbers to match the scenario you're testing.
+Archivematica 1.17.x packages rely on Elasticsearch 6.x, while Archivematica
+1.18.x (and newer) use Elasticsearch 8.x. The install and upgrade scripts honor
+`ELASTICSEARCH_PACKAGES_REPO_VERSION` and `ELASTICSEARCH_PACKAGE_VERSION`, so
+set them explicitly any time you need a non-default combination.
+
+```shell
+# Example: install 1.17.x as the baseline (Elasticsearch 6.x)
+podman-compose exec \
+    --env ARCHIVEMATICA_PACKAGES_REPO_VERSION=1.17.x \
+    --env ELASTICSEARCH_PACKAGES_REPO_VERSION=6.x \
+    --user ubuntu \
+    archivematica /am-packbuild/tests/archivematica/EL9/install.sh
+
+# Upgrade that container to 1.18.x (Elasticsearch 8.x)
+podman-compose exec \
+    --env ARCHIVEMATICA_PACKAGES_REPO_VERSION=1.18.x \
+    --env ELASTICSEARCH_PACKAGES_REPO_VERSION=8.x \
+    --user ubuntu \
+    archivematica /am-packbuild/tests/archivematica/EL9/upgrade.sh
+```
+
+### Upgrade EL9 packages from a local repository
+
+Build the local RPM repository as shown above. Install your baseline packages
+from whichever source you prefer (published repos or a previous local build),
+then rerun the upgrade with `LOCAL_REPOSITORY="yes"` so `upgrade.sh` pulls the
+new bits from `/am-packbuild/rpms/EL9/_yum_repository`. Remember to set
+`ELASTICSEARCH_PACKAGES_REPO_VERSION=6.x` when installing 1.17.x as the
+baseline, and switch it to `8.x` (or whichever version you are validating) for
+the upgrade.
+
+```shell
+podman-compose exec \
+    --env LOCAL_REPOSITORY="yes" \
+    --env ARCHIVEMATICA_PACKAGES_REPO_VERSION=1.18.x \
+    --env ELASTICSEARCH_PACKAGES_REPO_VERSION=8.x \
+    --user ubuntu \
+    archivematica /am-packbuild/tests/archivematica/EL9/upgrade.sh
 ```
 
 ### Install EL9 packages with Ansible
@@ -160,6 +209,47 @@ Install `jammy` packages using the local repository:
 
 ```shell
 podman-compose exec --env LOCAL_REPOSITORY="yes" --user ubuntu archivematica /am-packbuild/tests/archivematica/jammy/install.sh
+```
+
+### Upgrade jammy packages from archivematica.org
+
+Just like on EL9, reuse the same container: install the source release, then run
+`upgrade.sh` with the repository version that contains the packages you want to
+test. Match the Elasticsearch repository to the Archivematica version you're
+testing—1.17.x needs Elasticsearch 6.x, while 1.18.x uses 8.x.
+
+```shell
+# Install the baseline release (example: 1.17.x, Elasticsearch 6.x)
+podman-compose exec \
+    --env ARCHIVEMATICA_PACKAGES_REPO_VERSION=1.17.x \
+    --env ELASTICSEARCH_PACKAGES_REPO_VERSION=6.x \
+    --user ubuntu \
+    archivematica /am-packbuild/tests/archivematica/jammy/install.sh
+
+# Upgrade to the candidate release (example: 1.18.x, Elasticsearch 8.x)
+podman-compose exec \
+    --env ARCHIVEMATICA_PACKAGES_REPO_VERSION=1.18.x \
+    --env ELASTICSEARCH_PACKAGES_REPO_VERSION=8.x \
+    --user ubuntu \
+    archivematica /am-packbuild/tests/archivematica/jammy/upgrade.sh
+```
+
+### Upgrade jammy packages from a local repository
+
+Create the local APT repository first. When you are ready to test the new
+packages, run the upgrade with `LOCAL_REPOSITORY="yes"` so the script points
+APT at `/am-packbuild/debs/jammy/_deb_repository`. Use
+`ELASTICSEARCH_PACKAGES_REPO_VERSION` to ensure the right Elasticsearch release
+is installed at each step (e.g., 6.x for 1.17.x installs and 8.x for 1.18.x
+upgrades).
+
+```shell
+podman-compose exec \
+    --env LOCAL_REPOSITORY="yes" \
+    --env ARCHIVEMATICA_PACKAGES_REPO_VERSION=1.18.x \
+    --env ELASTICSEARCH_PACKAGES_REPO_VERSION=8.x \
+    --user ubuntu \
+    archivematica /am-packbuild/tests/archivematica/jammy/upgrade.sh
 ```
 
 ## Test the Archivematica installation

--- a/tests/archivematica/common/elasticsearch.sh
+++ b/tests/archivematica/common/elasticsearch.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+TEMP_ES6_DIR="/tmp/temp-es-6x"
+TEMP_ES6_PID_FILE="${TEMP_ES6_DIR}/elasticsearch-6.8.23/elastic-6x-tmp.pid"
+
+function setup_temp_elasticsearch6() {
+    local temp_dir="${TEMP_ES6_DIR}"
+    mkdir -p "${temp_dir}"
+
+    local java_bin
+    java_bin=$(readlink -f "$(which java)")
+    local java_home
+    java_home=$(dirname "$(dirname "${java_bin}")")
+    echo "Java 11 installed at: ${java_home}"
+
+    (
+        cd "${temp_dir}" || exit
+
+        local es_archive="elasticsearch-6.8.23.tar.gz"
+        local es_checksum="${es_archive}.sha512"
+
+        rm -f "${es_archive}" "${es_checksum}"
+        curl -fSLO "https://artifacts.elastic.co/downloads/elasticsearch/${es_archive}"
+        curl -fSLO "https://artifacts.elastic.co/downloads/elasticsearch/${es_checksum}"
+
+        if ! sha512sum --check --status "${es_checksum}"; then
+            echo "Failed to verify checksum for ${es_archive}" >&2
+            exit 1
+        fi
+        rm -f "${es_checksum}"
+
+        rm -rf elasticsearch-6.8.23
+        tar --extract --gzip --verbose --file "${es_archive}"
+
+        (
+            cd elasticsearch-6.8.23 || exit
+            sudo -u root rm -rf data
+            sudo -u root cp /var/lib/elasticsearch data --recursive --force
+            sudo -u root chown "$(whoami)":"$(whoami)" data --recursive
+            JAVA_HOME="${java_home}" ES_JAVA_OPTS="-Xms2g -Xmx2g" ./bin/elasticsearch \
+                --daemonize --pidfile elastic-6x-tmp.pid \
+                -Ehttp.port=9500 \
+                -Ediscovery.type=single-node
+        )
+    ) || return 1
+
+    wait_for_elasticsearch "http://localhost:9500"
+    curl --request GET "localhost:9500/_cat/indices?v"
+}
+
+function cleanup_temp_elasticsearch6() {
+    local pid_file="${TEMP_ES6_PID_FILE}"
+
+    if [ -f "${pid_file}" ]; then
+        local pid
+        pid=$(cat "${pid_file}")
+        if [ -n "${pid}" ] && kill -0 "${pid}" 2>/dev/null; then
+            kill "${pid}" || true
+        fi
+        rm -f "${pid_file}"
+    fi
+
+    sudo -u root rm -rf "${TEMP_ES6_DIR}/elasticsearch-6.8.23"
+    rm -f "${TEMP_ES6_DIR}/elasticsearch-6.8.23.tar.gz"
+}
+
+function reindex_elasticsearch_data() {
+    local indices=("aips" "aipfiles" "transfers" "transferfiles")
+
+    wait_for_elasticsearch "http://localhost:9200"
+
+    for index in "${indices[@]}"; do
+        curl --request POST "localhost:9200/_reindex?pretty" \
+            --header 'Content-Type: application/json' \
+            --data @- <<EOF
+{
+  "source": {
+    "remote": {
+      "host": "http://localhost:9500"
+    },
+    "index": "${index}"
+  },
+  "dest": {
+    "index": "${index}"
+  }
+}
+EOF
+    done
+
+    curl -X POST "http://localhost:9200/_flush"
+    curl --request GET "localhost:9200/_cat/indices?v"
+}

--- a/tests/archivematica/common/helpers.sh
+++ b/tests/archivematica/common/helpers.sh
@@ -7,6 +7,17 @@ ARCHIVEMATICA_SERVICES=(
     archivematica-storage-service
 )
 
+first_existing_dir() {
+    local dir
+    for dir in "$@"; do
+        if [ -d "${dir}" ]; then
+            echo "${dir}"
+            return 0
+        fi
+    done
+    return 1
+}
+
 function get_env_boolean() {
     local name="$1"
     local default="$2"
@@ -29,13 +40,17 @@ function get_env_boolean() {
 
 function stop_archivematica_services() {
     for service in "${ARCHIVEMATICA_SERVICES[@]}"; do
-        sudo -u root systemctl stop "${service}"
+        if ! sudo -u root systemctl stop "${service}"; then
+            echo "Warning: could not stop ${service}; continuing" >&2
+        fi
     done
 }
 
 function restart_archivematica_services() {
     for service in "${ARCHIVEMATICA_SERVICES[@]}"; do
-        sudo -u root systemctl restart "${service}"
+        if ! sudo -u root systemctl restart "${service}"; then
+            echo "Warning: could not restart ${service}; continuing" >&2
+        fi
     done
 }
 
@@ -101,12 +116,46 @@ enabled=1
 EOF"
 }
 
-function append_env_var() {
+function set_env_var() {
     local file="$1"
     local variable="$2"
     local value="$3"
 
-    echo "${variable}=${value}" | sudo -u root tee -a "${file}" >/dev/null
+    sudo -u root touch "${file}"
+
+    local escaped_variable
+    escaped_variable=$(printf '%s' "${variable}" | sed -e 's/[][\\\/.^$*+?|(){}-]/\\&/g')
+
+    if sudo -u root grep -qE "^${escaped_variable}=" "${file}"; then
+        sudo -u root sed -i -E "s|^${escaped_variable}=.*|${variable}=${value}|" "${file}"
+    else
+        echo "${variable}=${value}" | sudo -u root tee -a "${file}" >/dev/null
+    fi
+}
+
+function ensure_elasticsearch_setting() {
+    local key="$1"
+    local value="$2"
+    local file="${3:-/etc/elasticsearch/elasticsearch.yml}"
+
+    local key_regex
+    key_regex=$(printf '%s' "${key}" | sed -e 's/[][\\\/.^$*+?|(){}]/\\&/g')
+
+    local match_regex="^[[:space:]]*${key_regex}:"
+
+    if sudo -u root grep -Eq "${match_regex}" "${file}"; then
+        sudo -u root sed -i -E "s|${match_regex}.*|${key}: ${value}|" "${file}"
+    else
+        printf '%s: %s\n' "${key}" "${value}" | sudo -u root tee -a "${file}" >/dev/null
+    fi
+}
+
+function configure_elasticsearch_settings() {
+    sudo -u root sed -i 's/^xpack\.security\.enabled:.*/xpack.security.enabled: false/' /etc/elasticsearch/elasticsearch.yml
+    sudo -u root sed -i '/xpack\.security\.http\.ssl:/,/^xpack\.security/{s/^\(\s*\)enabled:.*/\1enabled: false/}' /etc/elasticsearch/elasticsearch.yml
+    sudo -u root sed -i '/xpack\.security\.transport\.ssl:/,/^xpack\.security/{s/^\(\s*\)enabled:.*/\1enabled: false/}' /etc/elasticsearch/elasticsearch.yml
+    ensure_elasticsearch_setting "reindex.remote.whitelist" "localhost:9500"
+    ensure_elasticsearch_setting "xpack.ml.enabled" "false"
 }
 
 function set_search_env_flags() {
@@ -122,13 +171,13 @@ function set_search_env_flags() {
     for component in "${components[@]}"; do
         case "${component}" in
             dashboard)
-                append_env_var "${base_dir}/archivematica-dashboard" "ARCHIVEMATICA_DASHBOARD_DASHBOARD_SEARCH_ENABLED" "${value}"
+                set_env_var "${base_dir}/archivematica-dashboard" "ARCHIVEMATICA_DASHBOARD_DASHBOARD_SEARCH_ENABLED" "${value}"
                 ;;
             mcp-server)
-                append_env_var "${base_dir}/archivematica-mcp-server" "ARCHIVEMATICA_MCPSERVER_MCPSERVER_SEARCH_ENABLED" "${value}"
+                set_env_var "${base_dir}/archivematica-mcp-server" "ARCHIVEMATICA_MCPSERVER_MCPSERVER_SEARCH_ENABLED" "${value}"
                 ;;
             mcp-client)
-                append_env_var "${base_dir}/archivematica-mcp-client" "ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_SEARCH_ENABLED" "${value}"
+                set_env_var "${base_dir}/archivematica-mcp-client" "ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_SEARCH_ENABLED" "${value}"
                 ;;
             *)
                 echo "Unknown component '${component}'" >&2
@@ -168,7 +217,7 @@ function run_archivematica_manage() {
 
     local env_candidates=()
     local virtualenv_python=""
-    local module=""
+    local module_candidates=()
 
     case "${component}" in
         storage-service)
@@ -177,7 +226,10 @@ function run_archivematica_manage() {
                 /etc/sysconfig/archivematica-storage-service
             )
             virtualenv_python=/usr/share/archivematica/virtualenvs/archivematica-storage-service/bin/python
-            module=archivematica.storage_service.manage
+            module_candidates=(
+                archivematica.storage_service.manage
+                storage_service.manage
+            )
             ;;
         dashboard)
             env_candidates=(
@@ -185,7 +237,10 @@ function run_archivematica_manage() {
                 /etc/sysconfig/archivematica-dashboard
             )
             virtualenv_python=/usr/share/archivematica/virtualenvs/archivematica/bin/python
-            module=archivematica.dashboard.manage
+            module_candidates=(
+                archivematica.dashboard.manage
+                dashboard.manage
+            )
             ;;
         *)
             echo "Unknown component '${component}'" >&2
@@ -206,7 +261,64 @@ function run_archivematica_manage() {
         exit 1
     fi
 
-    local command=("${virtualenv_python}" -m "${module}" "$@")
+    local module=""
+    for candidate_module in "${module_candidates[@]}"; do
+        if sudo -u archivematica bash -c "set -a -e
+source ${env_file}
+${virtualenv_python} -c \"import importlib.util, sys; sys.exit(0 if importlib.util.find_spec('${candidate_module}') else 1)\"
+" >/dev/null 2>&1; then
+            module="${candidate_module}"
+            break
+        fi
+    done
+
+    local command=()
+    local activate_path=""
+    if [ -n "${module}" ]; then
+        command=("${virtualenv_python}" "-m" "${module}" "$@")
+        activate_path=$(dirname "${virtualenv_python}")/activate
+    else
+        # Fall back to manage.py for very old virtualenv layouts lacking modules.
+        local manage_py=""
+        local manage_candidates=()
+        case "${component}" in
+            storage-service)
+                manage_candidates=(
+                    /usr/share/archivematica/storage-service/manage.py
+                    /usr/lib/archivematica/storage-service/manage.py
+                )
+                ;;
+            dashboard)
+                # Older 1.17.x packages install manage.py under dashboard/.
+                manage_candidates=(
+                    /usr/share/archivematica/dashboard/manage.py
+                    /usr/lib/archivematica/dashboard/manage.py
+                )
+                ;;
+        esac
+
+        for candidate_manage in "${manage_candidates[@]}"; do
+            if [ -f "${candidate_manage}" ]; then
+                manage_py="${candidate_manage}"
+                break
+            fi
+        done
+
+        if [ ! -f "${manage_py}" ]; then
+            echo "Unable to find Python manage module for component '${component}'" >&2
+            exit 1
+        fi
+
+        local manage_dir
+        manage_dir=$(dirname "${manage_py}")
+        local default_venv="${manage_dir}/../src/virtualenv/bin/activate"
+        if [ ! -f "${default_venv}" ]; then
+            default_venv="${manage_dir}/../src/dashboard/virtualenv/bin/activate"
+        fi
+
+        command=("${virtualenv_python}" "${manage_py}" "$@")
+        activate_path="${default_venv}"
+    fi
     local command_string=""
     printf -v command_string '%q ' "${command[@]}"
     command_string=${command_string% }
@@ -214,6 +326,10 @@ function run_archivematica_manage() {
     local script="set -a -e -x
 source ${env_file}
 "
+    if [ -n "${activate_path}" ] && [ -f "${activate_path}" ]; then
+        script+="source ${activate_path}
+"
+    fi
     if [ -n "${chdir}" ]; then
         script+="cd ${chdir}
 "
@@ -227,6 +343,7 @@ source ${env_file}
 function install_elasticsearch_deb() {
     local repo_version="${1:-${ELASTICSEARCH_PACKAGES_REPO_VERSION:-8.x}}"
     local package_version="${2:-${ELASTICSEARCH_PACKAGE_VERSION:-}}"
+    local local_repository="${3:-$(get_env_boolean "LOCAL_REPOSITORY" "false")}"
     local version_slug="${repo_version//\//-}"
     local keyring_path="/etc/apt/keyrings/elasticsearch-${version_slug}.gpg"
     local repo_file="/etc/apt/sources.list.d/elasticsearch-${version_slug}.list"
@@ -237,16 +354,19 @@ function install_elasticsearch_deb() {
 deb [signed-by=${keyring_path}] https://artifacts.elastic.co/packages/${repo_version}/apt stable main
 EOF"
 
-    sudo -u root apt-get -o Acquire::AllowInsecureRepositories=true update
+    local apt_update_cmd=(sudo -u root apt-get)
+    if [ "${local_repository}" == "true" ]; then
+        apt_update_cmd+=(-o Acquire::AllowInsecureRepositories=true)
+    fi
+    apt_update_cmd+=(update)
+    "${apt_update_cmd[@]}"
     if [ -n "${package_version}" ]; then
         sudo -u root apt-get install -y "elasticsearch=${package_version}"
     else
         sudo -u root apt-get install -y elasticsearch
     fi
 
-    sudo -u root sed -i 's/^xpack\.security\.enabled:.*/xpack.security.enabled: false/' /etc/elasticsearch/elasticsearch.yml
-    sudo -u root sed -i '/xpack\.security\.http\.ssl:/,/^xpack\.security/{s/^\(\s*\)enabled:.*/\1enabled: false/}' /etc/elasticsearch/elasticsearch.yml
-    sudo -u root sed -i '/xpack\.security\.transport\.ssl:/,/^xpack\.security/{s/^\(\s*\)enabled:.*/\1enabled: false/}' /etc/elasticsearch/elasticsearch.yml
+    configure_elasticsearch_settings
 
     sudo -u root systemctl daemon-reload
     sudo -u root service elasticsearch restart
@@ -279,9 +399,7 @@ EOF"
         sudo -u root yum install -y elasticsearch
     fi
 
-    sudo -u root sed -i 's/^xpack\.security\.enabled:.*/xpack.security.enabled: false/' /etc/elasticsearch/elasticsearch.yml
-    sudo -u root sed -i '/xpack\.security\.http\.ssl:/,/^xpack\.security/{s/^\(\s*\)enabled:.*/\1enabled: false/}' /etc/elasticsearch/elasticsearch.yml
-    sudo -u root sed -i '/xpack\.security\.transport\.ssl:/,/^xpack\.security/{s/^\(\s*\)enabled:.*/\1enabled: false/}' /etc/elasticsearch/elasticsearch.yml
+    configure_elasticsearch_settings
 
     sudo -u root systemctl enable elasticsearch
     sudo -u root systemctl start elasticsearch

--- a/tests/archivematica/jammy/install.sh
+++ b/tests/archivematica/jammy/install.sh
@@ -8,6 +8,22 @@ THIS_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=tests/archivematica/common/helpers.sh
 source "${THIS_DIR}/../common/helpers.sh"
 
+wait_for_service_active() {
+    local service="$1"
+    local timeout="${2:-120}"
+    local interval="${3:-5}"
+    local elapsed=0
+
+    until sudo systemctl is-active --quiet "${service}"; do
+        if [ "${elapsed}" -ge "${timeout}" ]; then
+            echo "Service ${service} did not become active within ${timeout}s" >&2
+            return 1
+        fi
+        sleep "${interval}"
+        elapsed=$((elapsed + interval))
+    done
+}
+
 search_enabled=$(get_env_boolean "SEARCH_ENABLED" "true")
 local_repository=$(get_env_boolean "LOCAL_REPOSITORY" "false")
 packages_repo_version="${ARCHIVEMATICA_PACKAGES_REPO_VERSION:-1.18.x}"
@@ -33,7 +49,11 @@ sudo debconf-set-selections <<< "archivematica-mcp-server archivematica-mcp-serv
 
 configure_archivematica_apt_repos "${local_repository}" "${packages_repo_version}"
 
-sudo apt-get -o Acquire::AllowInsecureRepositories=true update
+if [ "${local_repository}" == "true" ]; then
+    sudo apt-get -o Acquire::AllowInsecureRepositories=true update
+else
+    sudo apt-get update
+fi
 sudo apt-get -y upgrade
 
 sudo apt-get install -y openjdk-8-jre-headless mysql-server
@@ -42,33 +62,38 @@ sudo service mysql restart
 sudo systemctl enable mysql
 
 if [ "${search_enabled}" == "true" ] ; then
-    install_elasticsearch_deb "${elasticsearch_repo_version}" "${elasticsearch_package_version}"
+    install_elasticsearch_deb "${elasticsearch_repo_version}" "${elasticsearch_package_version}" "${local_repository}"
 fi
 
-sudo apt-get install -y --allow-unauthenticated archivematica-storage-service
+apt_auth_flags=()
+if [ "${local_repository}" == "true" ]; then
+    apt_auth_flags+=("--allow-unauthenticated")
+fi
+
+sudo apt-get install -y "${apt_auth_flags[@]}" archivematica-storage-service
 
 sudo rm -f /etc/nginx/sites-enabled/default
 sudo ln -sf /etc/nginx/sites-available/storage /etc/nginx/sites-enabled/storage
 
-sudo apt-get install -y --allow-unauthenticated archivematica-mcp-server
+sudo apt-get install -y "${apt_auth_flags[@]}" archivematica-mcp-server
 if [ "${search_enabled}" != "true" ] ; then
     set_search_env_flags "/etc/default" "false" "mcp-server"
 fi
 
-sudo apt-get install -y --allow-unauthenticated archivematica-dashboard
+sudo apt-get install -y "${apt_auth_flags[@]}" archivematica-dashboard
 if [ "${search_enabled}" != "true" ] ; then
     set_search_env_flags "/etc/default" "false" "dashboard"
 fi
 
-sudo apt-get install -y --allow-unauthenticated archivematica-mcp-client
+sudo apt-get install -y "${apt_auth_flags[@]}" archivematica-mcp-client
 if [ "${search_enabled}" != "true" ] ; then
     set_search_env_flags "/etc/default" "false" "mcp-client"
 fi
 
 sudo ln -sf /etc/nginx/sites-available/dashboard.conf /etc/nginx/sites-enabled/dashboard.conf
 
-sudo service clamav-freshclam restart
-sleep 120s
+sudo systemctl restart clamav-freshclam
+wait_for_service_active "clamav-freshclam" 120 5
 declare -a SERVICE_OPERATIONS=(
     "start clamav-daemon"
     "restart gearman-job-server"
@@ -103,8 +128,27 @@ run_archivematica_manage dashboard install \
     --ss-api-key="apikey" \
     --site-url="http://localhost"
 
+if ! dashboard_code_dir=$(
+    first_existing_dir \
+        /opt/archivematica/archivematica \
+        /usr/share/archivematica/dashboard \
+        /usr/lib/archivematica/dashboard
+); then
+    echo "Unable to locate dashboard source directory" >&2
+    exit 1
+fi
+
 run_archivematica_manage dashboard collectstatic --noinput --clear
-run_archivematica_manage dashboard --chdir /opt/archivematica/archivematica compilemessages
+run_archivematica_manage dashboard --chdir "${dashboard_code_dir}" compilemessages
 
 run_archivematica_manage storage-service collectstatic --noinput --clear
-run_archivematica_manage storage-service --chdir /opt/archivematica/archivematica-storage-service/ compilemessages
+if ! storage_service_code_dir=$(
+    first_existing_dir \
+        /opt/archivematica/archivematica-storage-service \
+        /usr/share/archivematica/storage-service \
+        /usr/lib/archivematica/storage-service
+); then
+    echo "Unable to locate storage service source directory" >&2
+    exit 1
+fi
+run_archivematica_manage storage-service --chdir "${storage_service_code_dir}" compilemessages

--- a/tests/archivematica/jammy/upgrade.sh
+++ b/tests/archivematica/jammy/upgrade.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -x
+
+THIS_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=tests/archivematica/common/helpers.sh
+source "${THIS_DIR}/../common/helpers.sh"
+# shellcheck source=tests/archivematica/common/elasticsearch.sh
+source "${THIS_DIR}/../common/elasticsearch.sh"
+
+trap cleanup_temp_elasticsearch6 EXIT
+
+local_repository=$(get_env_boolean "LOCAL_REPOSITORY" "false")
+packages_repo_version="${ARCHIVEMATICA_PACKAGES_REPO_VERSION:-1.18.x}"
+elasticsearch_repo_version="${ELASTICSEARCH_PACKAGES_REPO_VERSION:-8.x}"
+elasticsearch_package_version="${ELASTICSEARCH_PACKAGE_VERSION:-}"
+
+dump_lowercase_environment_variables
+echo "Using Archivematica packages repository version: ${packages_repo_version}"
+echo "Using Elasticsearch packages repository version: ${elasticsearch_repo_version}"
+if [ -n "${elasticsearch_package_version}" ]; then
+    echo "Using Elasticsearch package version: ${elasticsearch_package_version}"
+fi
+
+# Stop Archivematica services.
+stop_archivematica_services
+
+# Back up Elasticsearch data.
+sudo -u root systemctl stop elasticsearch
+sudo -u root tar --create --gzip --file "/root/var_lib_elasticsearch_$(date +%y%m%d).tgz" /var/lib/elasticsearch
+
+# Set up temporary Elasticsearch 6.x instance.
+if [ "${local_repository}" == "true" ]; then
+    sudo -u root apt-get -o Acquire::AllowInsecureRepositories=true update
+else
+    sudo -u root apt-get update
+fi
+sudo -u root apt-get install -y openjdk-11-jdk gnupg
+
+# Set up Elasticsearch 6.x.
+setup_temp_elasticsearch6
+
+# Back up Elasticsearch 6.x directories.
+sudo -u root cp -a /etc/elasticsearch /etc/elasticsearch-6
+sudo -u root cp -a /var/lib/elasticsearch /var/lib/elasticsearch-6
+sudo -u root cp -a /var/log/elasticsearch /var/log/elasticsearch-6
+
+# Remove Elasticsearch 6.x.
+sudo -u root apt-get purge -y elasticsearch
+sudo -u root rm -rf /var/lib/elasticsearch /var/log/elasticsearch /etc/elasticsearch
+
+# Install Elasticsearch 8.x.
+install_elasticsearch_deb "${elasticsearch_repo_version}" "${elasticsearch_package_version}" "${local_repository}"
+
+sudo -u root systemctl restart elasticsearch
+wait_for_elasticsearch "http://localhost:9200"
+
+#
+# Configure repository
+#
+
+configure_archivematica_apt_repos "${local_repository}" "${packages_repo_version}"
+
+if [ "${local_repository}" == "true" ]; then
+    sudo -u root apt-get -o Acquire::AllowInsecureRepositories=true update
+else
+    sudo -u root apt-get update
+fi
+
+apt_upgrade_cmd=(
+    sudo -u root apt-get install -y
+    -o Dpkg::Options::="--force-confnew"
+    -o Dpkg::Options::="--force-confmiss"
+)
+if [ "${local_repository}" == "true" ]; then
+    apt_upgrade_cmd+=("--allow-unauthenticated")
+fi
+apt_upgrade_cmd+=(
+    archivematica-storage-service
+)
+"${apt_upgrade_cmd[@]}"
+
+apt_upgrade_cmd=(
+    sudo -u root apt-get install -y
+    -o Dpkg::Options::="--force-confnew"
+    -o Dpkg::Options::="--force-confmiss"
+)
+if [ "${local_repository}" == "true" ]; then
+    apt_upgrade_cmd+=("--allow-unauthenticated")
+fi
+apt_upgrade_cmd+=(
+    archivematica
+    archivematica-common
+)
+"${apt_upgrade_cmd[@]}"
+
+apt_upgrade_cmd=(
+    sudo -u root apt-get install -y
+    -o Dpkg::Options::="--force-confnew"
+    -o Dpkg::Options::="--force-confmiss"
+)
+if [ "${local_repository}" == "true" ]; then
+    apt_upgrade_cmd+=("--allow-unauthenticated")
+fi
+apt_upgrade_cmd+=(
+    archivematica-dashboard
+    archivematica-mcp-server
+    archivematica-mcp-client
+)
+
+"${apt_upgrade_cmd[@]}"
+
+restart_archivematica_services
+
+# Reindex Elasticsearch data.
+reindex_elasticsearch_data
+
+# Delete temporary Elasticsearch 6.x instance.
+cleanup_temp_elasticsearch6
+trap - EXIT


### PR DESCRIPTION
This adds end-to-end upgrade testing for Archivematica's DEB and RPM
packages, ensuring that package upgrades from baseline versions
succeed reliably and that the system remains functional after
upgrading.

Connected to https://github.com/archivematica/Issues/issues/1766