### PR TITLE
Delete build artifacts from AM Ubuntu packages

### DIFF
--- a/.github/workflows/test-am-debs.yml
+++ b/.github/workflows/test-am-debs.yml
@@ -7,6 +7,11 @@ on:
         required: false
         default: "1.18.x"
         type: "string"
+      archivematica_packages_repo_baseurl:
+        description: "Optional Archivematica DEB repository base URL (version root; codename appended automatically)"
+        required: false
+        default: ""
+        type: "string"
       build_packages:
         description: "Build local packages"
         required: true
@@ -32,6 +37,7 @@ on:
 
 env:
   ARCHIVEMATICA_PACKAGES_REPO_VERSION: ${{ inputs.archivematica_packages_repo_version || '1.18.x' }}
+  ARCHIVEMATICA_PACKAGES_REPO_BASEURL: ${{ inputs.archivematica_packages_repo_baseurl || '' }}
 jobs:
   build-am-packages:
     name: Build Archivematica packages (${{ matrix.codename }})
@@ -174,6 +180,7 @@ jobs:
         podman-compose exec \
           --env LOCAL_REPOSITORY="${{ env.build_packages }}" \
           --env ARCHIVEMATICA_PACKAGES_REPO_VERSION="${{ env.ARCHIVEMATICA_PACKAGES_REPO_VERSION }}" \
+          --env ARCHIVEMATICA_PACKAGES_REPO_BASEURL="${{ env.ARCHIVEMATICA_PACKAGES_REPO_BASEURL }}" \
           --user ubuntu \
           archivematica \
           /am-packbuild/tests/archivematica/ubuntu/install.sh

--- a/.github/workflows/test-am-rpms.yml
+++ b/.github/workflows/test-am-rpms.yml
@@ -7,6 +7,11 @@ on:
         required: false
         default: "1.18.x"
         type: "string"
+      archivematica_packages_repo_baseurl:
+        description: "Optional Archivematica RPM repository base URL"
+        required: false
+        default: ""
+        type: "string"
       build_packages:
         description: "Build local packages"
         required: true
@@ -34,6 +39,7 @@ on:
 
 env:
   ARCHIVEMATICA_PACKAGES_REPO_VERSION: ${{ inputs.archivematica_packages_repo_version || '1.18.x' }}
+  ARCHIVEMATICA_PACKAGES_REPO_BASEURL: ${{ inputs.archivematica_packages_repo_baseurl || '' }}
 jobs:
   build-am-packages:
     name: Build Archivematica packages
@@ -142,6 +148,7 @@ jobs:
         podman-compose exec \
           --env LOCAL_REPOSITORY="${{ env.build_packages }}" \
           --env ARCHIVEMATICA_PACKAGES_REPO_VERSION="${{ env.ARCHIVEMATICA_PACKAGES_REPO_VERSION }}" \
+          --env ARCHIVEMATICA_PACKAGES_REPO_BASEURL="${{ env.ARCHIVEMATICA_PACKAGES_REPO_BASEURL }}" \
           --user ubuntu \
           archivematica \
           /am-packbuild/tests/archivematica/EL9/install.sh

--- a/.github/workflows/test-am-upgrade-debs.yml
+++ b/.github/workflows/test-am-upgrade-debs.yml
@@ -7,6 +7,11 @@ on:
         required: false
         default: "1.17.x"
         type: "string"
+      baseline_archivematica_packages_repo_baseurl:
+        description: "Optional baseline Archivematica DEB repository base URL (version root; codename appended automatically)"
+        required: false
+        default: ""
+        type: "string"
       baseline_elasticsearch_repo_version:
         description: "Elasticsearch repository version for the baseline install (e.g. 6.x)"
         required: false
@@ -16,6 +21,11 @@ on:
         description: "Archivematica packages repository version to upgrade to (e.g. 1.18.x)"
         required: false
         default: "1.18.x"
+        type: "string"
+      upgrade_archivematica_packages_repo_baseurl:
+        description: "Optional upgrade Archivematica DEB repository base URL (version root; codename appended automatically)"
+        required: false
+        default: ""
         type: "string"
       upgrade_elasticsearch_repo_version:
         description: "Elasticsearch repository version for the upgraded system (e.g. 8.x)"
@@ -47,8 +57,10 @@ on:
 
 env:
   BASELINE_ARCHIVEMATICA_PACKAGES_REPO_VERSION: ${{ inputs.baseline_archivematica_packages_repo_version || '1.17.x' }}
+  BASELINE_ARCHIVEMATICA_PACKAGES_REPO_BASEURL: ${{ inputs.baseline_archivematica_packages_repo_baseurl || '' }}
   BASELINE_ELASTICSEARCH_PACKAGES_REPO_VERSION: ${{ inputs.baseline_elasticsearch_repo_version || '6.x' }}
   UPGRADE_ARCHIVEMATICA_PACKAGES_REPO_VERSION: ${{ inputs.upgrade_archivematica_packages_repo_version || '1.18.x' }}
+  UPGRADE_ARCHIVEMATICA_PACKAGES_REPO_BASEURL: ${{ inputs.upgrade_archivematica_packages_repo_baseurl || '' }}
   UPGRADE_ELASTICSEARCH_PACKAGES_REPO_VERSION: ${{ inputs.upgrade_elasticsearch_repo_version || '8.x' }}
 
 jobs:
@@ -193,6 +205,7 @@ jobs:
         podman-compose exec \
           --env LOCAL_REPOSITORY="false" \
           --env ARCHIVEMATICA_PACKAGES_REPO_VERSION="${{ env.BASELINE_ARCHIVEMATICA_PACKAGES_REPO_VERSION }}" \
+          --env ARCHIVEMATICA_PACKAGES_REPO_BASEURL="${{ env.BASELINE_ARCHIVEMATICA_PACKAGES_REPO_BASEURL }}" \
           --env ELASTICSEARCH_PACKAGES_REPO_VERSION="${{ env.BASELINE_ELASTICSEARCH_PACKAGES_REPO_VERSION }}" \
           --user ubuntu \
           archivematica \
@@ -231,7 +244,9 @@ jobs:
         podman-compose exec \
           --env LOCAL_REPOSITORY="${{ env.build_packages }}" \
           --env ARCHIVEMATICA_PACKAGES_REPO_VERSION="${{ env.UPGRADE_ARCHIVEMATICA_PACKAGES_REPO_VERSION }}" \
+          --env ARCHIVEMATICA_PACKAGES_REPO_BASEURL="${{ env.UPGRADE_ARCHIVEMATICA_PACKAGES_REPO_BASEURL }}" \
           --env ELASTICSEARCH_PACKAGES_REPO_VERSION="${{ env.UPGRADE_ELASTICSEARCH_PACKAGES_REPO_VERSION }}" \
+          --env ELASTICSEARCH_MIGRATE_FROM_6X="${{ startsWith(env.BASELINE_ELASTICSEARCH_PACKAGES_REPO_VERSION, '6') }}" \
           --user ubuntu \
           archivematica \
           /am-packbuild/tests/archivematica/ubuntu/upgrade.sh

--- a/.github/workflows/test-am-upgrade-rpms.yml
+++ b/.github/workflows/test-am-upgrade-rpms.yml
@@ -7,6 +7,11 @@ on:
         required: false
         default: "1.17.x"
         type: "string"
+      baseline_archivematica_packages_repo_baseurl:
+        description: "Optional baseline Archivematica RPM repository base URL"
+        required: false
+        default: ""
+        type: "string"
       baseline_elasticsearch_repo_version:
         description: "Elasticsearch repository version for the baseline install (e.g. 6.x)"
         required: false
@@ -16,6 +21,11 @@ on:
         description: "Archivematica packages repository version to upgrade to (e.g. 1.18.x)"
         required: false
         default: "1.18.x"
+        type: "string"
+      upgrade_archivematica_packages_repo_baseurl:
+        description: "Optional upgrade Archivematica RPM repository base URL"
+        required: false
+        default: ""
         type: "string"
       upgrade_elasticsearch_repo_version:
         description: "Elasticsearch repository version for the upgraded system (e.g. 8.x)"
@@ -49,8 +59,10 @@ on:
 
 env:
   BASELINE_ARCHIVEMATICA_PACKAGES_REPO_VERSION: ${{ inputs.baseline_archivematica_packages_repo_version || '1.17.x' }}
+  BASELINE_ARCHIVEMATICA_PACKAGES_REPO_BASEURL: ${{ inputs.baseline_archivematica_packages_repo_baseurl || '' }}
   BASELINE_ELASTICSEARCH_PACKAGES_REPO_VERSION: ${{ inputs.baseline_elasticsearch_repo_version || '6.x' }}
   UPGRADE_ARCHIVEMATICA_PACKAGES_REPO_VERSION: ${{ inputs.upgrade_archivematica_packages_repo_version || '1.18.x' }}
+  UPGRADE_ARCHIVEMATICA_PACKAGES_REPO_BASEURL: ${{ inputs.upgrade_archivematica_packages_repo_baseurl || '' }}
   UPGRADE_ELASTICSEARCH_PACKAGES_REPO_VERSION: ${{ inputs.upgrade_elasticsearch_repo_version || '8.x' }}
 
 jobs:
@@ -161,7 +173,9 @@ jobs:
         podman-compose exec \
           --env LOCAL_REPOSITORY="false" \
           --env ARCHIVEMATICA_PACKAGES_REPO_VERSION="${{ env.BASELINE_ARCHIVEMATICA_PACKAGES_REPO_VERSION }}" \
+          --env ARCHIVEMATICA_PACKAGES_REPO_BASEURL="${{ env.BASELINE_ARCHIVEMATICA_PACKAGES_REPO_BASEURL }}" \
           --env ELASTICSEARCH_PACKAGES_REPO_VERSION="${{ env.BASELINE_ELASTICSEARCH_PACKAGES_REPO_VERSION }}" \
+          --env ELASTICSEARCH_MIGRATE_FROM_6X="${{ startsWith(env.BASELINE_ELASTICSEARCH_PACKAGES_REPO_VERSION, '6') }}" \
           --user ubuntu \
           archivematica \
           /am-packbuild/tests/archivematica/EL9/install.sh
@@ -199,7 +213,9 @@ jobs:
         podman-compose exec \
           --env LOCAL_REPOSITORY="${{ env.build_packages }}" \
           --env ARCHIVEMATICA_PACKAGES_REPO_VERSION="${{ env.UPGRADE_ARCHIVEMATICA_PACKAGES_REPO_VERSION }}" \
+          --env ARCHIVEMATICA_PACKAGES_REPO_BASEURL="${{ env.UPGRADE_ARCHIVEMATICA_PACKAGES_REPO_BASEURL }}" \
           --env ELASTICSEARCH_PACKAGES_REPO_VERSION="${{ env.UPGRADE_ELASTICSEARCH_PACKAGES_REPO_VERSION }}" \
+          --env ELASTICSEARCH_MIGRATE_FROM_6X="${{ startsWith(env.BASELINE_ELASTICSEARCH_PACKAGES_REPO_VERSION, '6') }}" \
           --user ubuntu \
           archivematica \
           /am-packbuild/tests/archivematica/EL9/upgrade.sh

--- a/debs/jammy/archivematica-storage-service/build.sh
+++ b/debs/jammy/archivematica-storage-service/build.sh
@@ -12,6 +12,7 @@ cd "$SOURCE"
 COMMIT=$(git rev-parse HEAD)
 cp -rf "${BASE}/debian-storage-service" debian
 mk-build-deps -i debian/control
+find . -maxdepth 1 -type f -name "*build-deps*.*" -delete
 dch -v "1:${VERSION}${RELEASE}~22.04" "commit: ${COMMIT}"
 dch -v "1:${VERSION}${RELEASE}~22.04" "checkout: ${BRANCH}"
 dch -r --distribution jammy --urgency high ignored

--- a/debs/jammy/archivematica/build.sh
+++ b/debs/jammy/archivematica/build.sh
@@ -8,11 +8,16 @@ export DEBFULLNAME="Artefactual Systems"
 export DEBEMAIL="sysadmin@artefactual.com"
 export DEB_BUILD_OPTIONS="noddebs"
 
+clean_build_deps_artifacts() {
+	find . -maxdepth 1 -type f -name "*build-deps*.*" -delete
+}
+
 # Create archivematica package.
 pushd "${SOURCE}"
 COMMIT=$(git rev-parse HEAD)
 cp -rf "${BASE}/debian-archivematica" debian
 mk-build-deps -i debian/control
+clean_build_deps_artifacts
 dch -v "1:${VERSION}${RELEASE}~22.04" "commit: ${COMMIT}"
 dch -v "1:${VERSION}${RELEASE}~22.04" "checkout: ${BRANCH}"
 dch -r --distribution jammy --urgency high ignored
@@ -24,6 +29,7 @@ for i in dashboard MCPClient MCPServer archivematicaCommon; do
 	pushd "${SOURCE}/src/archivematica/${i}"
 	cp -rf "${BASE}/debian-${i}" debian
 	mk-build-deps -i debian/control
+	clean_build_deps_artifacts
 	dch -v "1:${VERSION}${RELEASE}~22.04" "commit: ${COMMIT}"
 	dch -v "1:${VERSION}${RELEASE}~22.04" "checkout: ${BRANCH}"
 	dch -r --distribution jammy --urgency high ignored

--- a/debs/noble/archivematica-storage-service/build.sh
+++ b/debs/noble/archivematica-storage-service/build.sh
@@ -12,6 +12,7 @@ cd "$SOURCE"
 COMMIT=$(git rev-parse HEAD)
 cp -rf "${BASE}/debian-storage-service" debian
 mk-build-deps -i debian/control
+find . -maxdepth 1 -type f -name "*build-deps*.*" -delete
 dch -v "1:${VERSION}${RELEASE}~24.04" "commit: ${COMMIT}"
 dch -v "1:${VERSION}${RELEASE}~24.04" "checkout: ${BRANCH}"
 dch -r --distribution noble --urgency high ignored

--- a/debs/noble/archivematica/build.sh
+++ b/debs/noble/archivematica/build.sh
@@ -8,11 +8,16 @@ export DEBFULLNAME="Artefactual Systems"
 export DEBEMAIL="sysadmin@artefactual.com"
 export DEB_BUILD_OPTIONS="noddebs"
 
+clean_build_deps_artifacts() {
+	find . -maxdepth 1 -type f -name "*build-deps*.*" -delete
+}
+
 # Create archivematica package.
 pushd "${SOURCE}"
 COMMIT=$(git rev-parse HEAD)
 cp -rf "${BASE}/debian-archivematica" debian
 mk-build-deps -i debian/control
+clean_build_deps_artifacts
 dch -v "1:${VERSION}${RELEASE}~24.04" "commit: ${COMMIT}"
 dch -v "1:${VERSION}${RELEASE}~24.04" "checkout: ${BRANCH}"
 dch -r --distribution noble --urgency high ignored
@@ -24,6 +29,7 @@ for i in dashboard MCPClient MCPServer archivematicaCommon; do
 	pushd "${SOURCE}/src/archivematica/${i}"
 	cp -rf "${BASE}/debian-${i}" debian
 	mk-build-deps -i debian/control
+	clean_build_deps_artifacts
 	dch -v "1:${VERSION}${RELEASE}~24.04" "commit: ${COMMIT}"
 	dch -v "1:${VERSION}${RELEASE}~24.04" "checkout: ${BRANCH}"
 	dch -r --distribution noble --urgency high ignored

--- a/tests/archivematica/EL9/ansible/vars.yml
+++ b/tests/archivematica/EL9/ansible/vars.yml
@@ -2,6 +2,7 @@
 
 # archivematica-src role
 
+archivematica_packages_repo_baseurl: "{{ lookup('env', 'ARCHIVEMATICA_PACKAGES_REPO_BASEURL') | default('', true) | trim }}"
 archivematica_packages_repo_version: "{{ lookup('env', 'ARCHIVEMATICA_PACKAGES_REPO_VERSION') | default('1.18.x', true) }}"
 
 archivematica_src_configure_dashboard: "yes"
@@ -39,8 +40,14 @@ archivematica_src_install_ss: "rpm"
 install_rpm_repositories: "true"
 
 archivematica_src_rpm_repository_local_baseurl: "file:///am-packbuild/rpms/EL9/_yum_repository/"
-archivematica_src_rpm_repository_public_baseurl: "https://packages.archivematica.org/{{ archivematica_packages_repo_version }}/rocky9"
+archivematica_src_rpm_repository_public_baseurl: >-
+  {{ archivematica_packages_repo_baseurl
+     if archivematica_packages_repo_baseurl | length > 0
+     else "https://packages.archivematica.org/{{ archivematica_packages_repo_version }}/rocky9" }}
 archivematica_src_rpm_repository_use_local_baseurl: true
+archivematica_src_rpm_repository_gpgcheck: >-
+  {{ 0 if archivematica_src_rpm_repository_use_local_baseurl | bool
+     else (0 if archivematica_packages_repo_baseurl | length > 0 else 1) }}
 
 archivematica_src_rpm_repository_baseurl: >-
   {{ archivematica_src_rpm_repository_local_baseurl
@@ -50,7 +57,7 @@ archivematica_src_rpm_repository_baseurl: >-
 archivematica_src_rpm_repositories:
   archivematica:
     baseurl: "{{ archivematica_src_rpm_repository_baseurl }}"
-    gpgcheck: 0
+    gpgcheck: "{{ archivematica_src_rpm_repository_gpgcheck }}"
   archivematica-extras:
     baseurl: "https://packages.archivematica.org/{{ archivematica_packages_repo_version }}/rocky9-extras"
     gpgkey: "https://packages.archivematica.org/GPG-KEY-archivematica-sha512"

--- a/tests/archivematica/EL9/install.sh
+++ b/tests/archivematica/EL9/install.sh
@@ -11,11 +11,15 @@ source "${THIS_DIR}/../common/helpers.sh"
 search_enabled=$(get_env_boolean "SEARCH_ENABLED" "true")
 local_repository=$(get_env_boolean "LOCAL_REPOSITORY" "false")
 packages_repo_version="${ARCHIVEMATICA_PACKAGES_REPO_VERSION:-1.18.x}"
+packages_repo_baseurl="${ARCHIVEMATICA_PACKAGES_REPO_BASEURL:-}"
 elasticsearch_repo_version="${ELASTICSEARCH_PACKAGES_REPO_VERSION:-8.x}"
 elasticsearch_package_version="${ELASTICSEARCH_PACKAGE_VERSION:-}"
 
 dump_lowercase_environment_variables
 echo "Using Archivematica packages repository version: ${packages_repo_version}"
+if [ -n "${packages_repo_baseurl}" ]; then
+    echo "Using Archivematica packages repository base URL: ${packages_repo_baseurl}"
+fi
 echo "Using Elasticsearch packages repository version: ${elasticsearch_repo_version}"
 if [ -n "${elasticsearch_package_version}" ]; then
     echo "Using Elasticsearch package version: ${elasticsearch_package_version}"
@@ -26,7 +30,7 @@ fi
 # Configure repository
 #
 
-configure_archivematica_yum_repos "${local_repository}" "${packages_repo_version}"
+configure_archivematica_yum_repos "${local_repository}" "${packages_repo_version}" "${packages_repo_baseurl}"
 
 sudo -u root yum update -y
 sudo -u root yum install -y epel-release policycoreutils-python-utils yum-utils

--- a/tests/archivematica/EL9/upgrade.sh
+++ b/tests/archivematica/EL9/upgrade.sh
@@ -14,37 +14,45 @@ trap cleanup_temp_elasticsearch6 EXIT
 
 local_repository=$(get_env_boolean "LOCAL_REPOSITORY" "false")
 packages_repo_version="${ARCHIVEMATICA_PACKAGES_REPO_VERSION:-1.18.x}"
+packages_repo_baseurl="${ARCHIVEMATICA_PACKAGES_REPO_BASEURL:-}"
 elasticsearch_repo_version="${ELASTICSEARCH_PACKAGES_REPO_VERSION:-8.x}"
 elasticsearch_package_version="${ELASTICSEARCH_PACKAGE_VERSION:-}"
+elasticsearch_migrate_from_6x=$(get_env_boolean "ELASTICSEARCH_MIGRATE_FROM_6X" "true")
 
 dump_lowercase_environment_variables
 echo "Using Archivematica packages repository version: ${packages_repo_version}"
+if [ -n "${packages_repo_baseurl}" ]; then
+    echo "Using Archivematica packages repository base URL: ${packages_repo_baseurl}"
+fi
 echo "Using Elasticsearch packages repository version: ${elasticsearch_repo_version}"
 if [ -n "${elasticsearch_package_version}" ]; then
     echo "Using Elasticsearch package version: ${elasticsearch_package_version}"
 fi
+echo "Elasticsearch 6.x migration enabled: ${elasticsearch_migrate_from_6x}"
 
 # Stop Archivematica services.
 stop_archivematica_services
 
-# Back up Elasticsearch data.
-sudo -u root systemctl stop elasticsearch
-sudo -u root tar --create --gzip --file "/root/var_lib_elasticsearch_$(date +%y%m%d).tgz" /var/lib/elasticsearch
+if [ "${elasticsearch_migrate_from_6x}" == "true" ]; then
+    # Back up Elasticsearch data.
+    sudo -u root systemctl stop elasticsearch
+    sudo -u root tar --create --gzip --file "/root/var_lib_elasticsearch_$(date +%y%m%d).tgz" /var/lib/elasticsearch
 
-# Set up temporary Elasticsearch 6.x instance.
-sudo -u root yum install -y java-11-openjdk java-11-openjdk-devel
+    # Set up temporary Elasticsearch 6.x instance.
+    sudo -u root yum install -y java-11-openjdk java-11-openjdk-devel
 
-# Set up Elasticsearch 6.x.
-setup_temp_elasticsearch6
+    # Set up Elasticsearch 6.x.
+    setup_temp_elasticsearch6
 
-# Back up Elasticsearch 6.x directories.
-sudo -u root cp -a /etc/elasticsearch /etc/elasticsearch-6
-sudo -u root cp -a /var/lib/elasticsearch /var/lib/elasticsearch-6
-sudo -u root cp -a /var/log/elasticsearch /var/log/elasticsearch-6
+    # Back up Elasticsearch 6.x directories.
+    sudo -u root cp -a /etc/elasticsearch /etc/elasticsearch-6
+    sudo -u root cp -a /var/lib/elasticsearch /var/lib/elasticsearch-6
+    sudo -u root cp -a /var/log/elasticsearch /var/log/elasticsearch-6
 
-# Remove Elasticsearch 6.x.
-sudo -u root yum remove -y elasticsearch
-sudo -u root rm -rf /var/lib/elasticsearch /var/log/elasticsearch /etc/elasticsearch
+    # Remove Elasticsearch 6.x.
+    sudo -u root yum remove -y elasticsearch
+    sudo -u root rm -rf /var/lib/elasticsearch /var/log/elasticsearch /etc/elasticsearch
+fi
 
 # Install Elasticsearch 8.x.
 install_elasticsearch_rpm "${elasticsearch_repo_version}" "${elasticsearch_package_version}"
@@ -56,7 +64,7 @@ wait_for_elasticsearch "http://localhost:9200"
 # Configure repository
 #
 
-configure_archivematica_yum_repos "${local_repository}" "${packages_repo_version}"
+configure_archivematica_yum_repos "${local_repository}" "${packages_repo_version}" "${packages_repo_baseurl}"
 
 sudo -u root yum update -y
 
@@ -65,9 +73,11 @@ run_archivematica_manage dashboard migrate --noinput
 
 restart_archivematica_services
 
-# Reindex Elasticsearch data.
-reindex_elasticsearch_data
+if [ "${elasticsearch_migrate_from_6x}" == "true" ]; then
+    # Reindex Elasticsearch data.
+    reindex_elasticsearch_data
 
-# Delete temporary Elasticsearch 6.x instance.
-cleanup_temp_elasticsearch6
-trap - EXIT
+    # Delete temporary Elasticsearch 6.x instance.
+    cleanup_temp_elasticsearch6
+    trap - EXIT
+fi

--- a/tests/archivematica/common/helpers.sh
+++ b/tests/archivematica/common/helpers.sh
@@ -63,6 +63,7 @@ function dump_lowercase_environment_variables() {
 function configure_archivematica_apt_repos() {
     local local_repository="$1"
     local repo_version="${2:-${ARCHIVEMATICA_PACKAGES_REPO_VERSION:-1.18.x}}"
+    local repo_baseurl="${3:-${ARCHIVEMATICA_PACKAGES_REPO_BASEURL:-}}"
     local version_slug="${repo_version//\//-}"
     local keyring_path="/etc/apt/keyrings/archivematica-${version_slug}.gpg"
 
@@ -70,6 +71,34 @@ function configure_archivematica_apt_repos() {
     arch=$(dpkg --print-architecture)
     local version_codename
     version_codename=$(grep -Po '(?<=^VERSION_CODENAME=).+' /etc/os-release)
+
+    local remote_baseurl="http://packages.archivematica.org/${repo_version}/ubuntu"
+    local repo_options="arch=${arch} signed-by=${keyring_path}"
+    local repo_suite="${version_codename}"
+    local repo_component="main"
+    if [ -n "${repo_baseurl}" ]; then
+        remote_baseurl="${repo_baseurl%/}"
+        repo_options="arch=${arch} trusted=yes"
+        # If the provided base URL ends with a codename, switch it to the
+        # current codename when needed; otherwise append the codename.
+        if [[ "${remote_baseurl}" =~ /(jammy|noble)(/)?$ ]]; then
+            if [ "${BASH_REMATCH[1]}" != "${version_codename}" ]; then
+                remote_baseurl="${remote_baseurl%/*}/${version_codename}"
+            fi
+        elif [[ ! "${remote_baseurl}" =~ /${version_codename}(/)?$ ]]; then
+            remote_baseurl="${remote_baseurl}/${version_codename}"
+        fi
+        # Custom repos from Jenkins are flat (no dists tree), so use ./ to read Packages directly.
+        repo_suite="./"
+        repo_component=""
+    fi
+
+    local repo_line=""
+    if [ -n "${repo_component}" ]; then
+        repo_line="deb [${repo_options}] ${remote_baseurl} ${repo_suite} ${repo_component}"
+    else
+        repo_line="deb [${repo_options}] ${remote_baseurl} ${repo_suite}"
+    fi
 
     sudo -u root install -d -m 0755 /etc/apt/keyrings
     curl -fsSL "https://packages.archivematica.org/${repo_version}/key.asc" | sudo -u root gpg --dearmor --yes -o "${keyring_path}"
@@ -84,7 +113,7 @@ EOF"
     else
 
         sudo -u root bash -c "cat <<EOF > /etc/apt/sources.list.d/archivematica.list
-deb [arch=${arch} signed-by=${keyring_path}] http://packages.archivematica.org/${repo_version}/ubuntu ${version_codename} main
+${repo_line}
 EOF"
     fi
 }
@@ -92,6 +121,14 @@ EOF"
 function configure_archivematica_yum_repos() {
     local local_repository="$1"
     local repo_version="${2:-${ARCHIVEMATICA_PACKAGES_REPO_VERSION:-1.18.x}}"
+    local repo_baseurl="${3:-${ARCHIVEMATICA_PACKAGES_REPO_BASEURL:-}}"
+
+    local remote_baseurl="https://packages.archivematica.org/${repo_version}/rocky9"
+    local gpgcheck="1"
+    if [ -n "${repo_baseurl}" ]; then
+        remote_baseurl="${repo_baseurl%/}"
+        gpgcheck="0"
+    fi
 
     if [ "${local_repository}" == "true" ]; then
         sudo -u root bash -c 'cat << EOF > /etc/yum.repos.d/archivematica.repo
@@ -105,11 +142,15 @@ EOF'
         sudo -u root bash -c "cat <<EOF > /etc/yum.repos.d/archivematica.repo
 [archivematica]
 name=archivematica
-baseurl=https://packages.archivematica.org/${repo_version}/rocky9
-gpgcheck=1
-gpgkey=https://packages.archivematica.org/GPG-KEY-archivematica-sha512
+baseurl=${remote_baseurl}
+gpgcheck=${gpgcheck}
 enabled=1
 EOF"
+        if [ "${gpgcheck}" == "1" ]; then
+            sudo -u root bash -c "cat <<'EOF' >> /etc/yum.repos.d/archivematica.repo
+gpgkey=https://packages.archivematica.org/GPG-KEY-archivematica-sha512
+EOF"
+        fi
     fi
 
     sudo -u root bash -c "cat <<EOF > /etc/yum.repos.d/archivematica-extras.repo

--- a/tests/archivematica/ubuntu/install.sh
+++ b/tests/archivematica/ubuntu/install.sh
@@ -27,11 +27,15 @@ wait_for_service_active() {
 search_enabled=$(get_env_boolean "SEARCH_ENABLED" "true")
 local_repository=$(get_env_boolean "LOCAL_REPOSITORY" "false")
 packages_repo_version="${ARCHIVEMATICA_PACKAGES_REPO_VERSION:-1.18.x}"
+packages_repo_baseurl="${ARCHIVEMATICA_PACKAGES_REPO_BASEURL:-}"
 elasticsearch_repo_version="${ELASTICSEARCH_PACKAGES_REPO_VERSION:-8.x}"
 elasticsearch_package_version="${ELASTICSEARCH_PACKAGE_VERSION:-}"
 
 dump_lowercase_environment_variables
 echo "Using Archivematica packages repository version: ${packages_repo_version}"
+if [ -n "${packages_repo_baseurl}" ]; then
+    echo "Using Archivematica packages repository base URL: ${packages_repo_baseurl}"
+fi
 echo "Using Elasticsearch packages repository version: ${elasticsearch_repo_version}"
 if [ -n "${elasticsearch_package_version}" ]; then
     echo "Using Elasticsearch package version: ${elasticsearch_package_version}"
@@ -47,7 +51,7 @@ sudo debconf-set-selections <<< "archivematica-mcp-server archivematica-mcp-serv
 sudo debconf-set-selections <<< "archivematica-mcp-server archivematica-mcp-server/mysql/app-pass password demo-am"
 sudo debconf-set-selections <<< "archivematica-mcp-server archivematica-mcp-server/app-password-confirm password demo-am"
 
-configure_archivematica_apt_repos "${local_repository}" "${packages_repo_version}"
+configure_archivematica_apt_repos "${local_repository}" "${packages_repo_version}" "${packages_repo_baseurl}"
 
 if [ "${local_repository}" == "true" ]; then
     sudo apt-get -o Acquire::AllowInsecureRepositories=true update

--- a/tests/archivematica/ubuntu/upgrade.sh
+++ b/tests/archivematica/ubuntu/upgrade.sh
@@ -14,44 +14,52 @@ trap cleanup_temp_elasticsearch6 EXIT
 
 local_repository=$(get_env_boolean "LOCAL_REPOSITORY" "false")
 packages_repo_version="${ARCHIVEMATICA_PACKAGES_REPO_VERSION:-1.18.x}"
+packages_repo_baseurl="${ARCHIVEMATICA_PACKAGES_REPO_BASEURL:-}"
 elasticsearch_repo_version="${ELASTICSEARCH_PACKAGES_REPO_VERSION:-8.x}"
 elasticsearch_package_version="${ELASTICSEARCH_PACKAGE_VERSION:-}"
+elasticsearch_migrate_from_6x=$(get_env_boolean "ELASTICSEARCH_MIGRATE_FROM_6X" "true")
 
 dump_lowercase_environment_variables
 echo "Using Archivematica packages repository version: ${packages_repo_version}"
+if [ -n "${packages_repo_baseurl}" ]; then
+    echo "Using Archivematica packages repository base URL: ${packages_repo_baseurl}"
+fi
 echo "Using Elasticsearch packages repository version: ${elasticsearch_repo_version}"
 if [ -n "${elasticsearch_package_version}" ]; then
     echo "Using Elasticsearch package version: ${elasticsearch_package_version}"
 fi
+echo "Elasticsearch 6.x migration enabled: ${elasticsearch_migrate_from_6x}"
 
 # Stop Archivematica services.
 stop_archivematica_services
 
-# Back up Elasticsearch data.
-sudo -u root systemctl stop elasticsearch
-sudo -u root tar --create --gzip --file "/root/var_lib_elasticsearch_$(date +%y%m%d).tgz" /var/lib/elasticsearch
+if [ "${elasticsearch_migrate_from_6x}" == "true" ]; then
+    # Back up Elasticsearch data.
+    sudo -u root systemctl stop elasticsearch
+    sudo -u root tar --create --gzip --file "/root/var_lib_elasticsearch_$(date +%y%m%d).tgz" /var/lib/elasticsearch
 
-# Set up temporary Elasticsearch 6.x instance.
-if [ "${local_repository}" == "true" ]; then
-    sudo -u root apt-get -o Acquire::AllowInsecureRepositories=true update
-else
-    sudo -u root apt-get update
+    # Set up temporary Elasticsearch 6.x instance.
+    if [ "${local_repository}" == "true" ]; then
+        sudo -u root apt-get -o Acquire::AllowInsecureRepositories=true update
+    else
+        sudo -u root apt-get update
+    fi
+    sudo -u root apt-get install -y openjdk-11-jdk gnupg
+
+    # Set up Elasticsearch 6.x.
+    setup_temp_elasticsearch6
+
+    # Back up Elasticsearch 6.x directories.
+    sudo -u root cp -a /etc/elasticsearch /etc/elasticsearch-6
+    sudo -u root cp -a /var/lib/elasticsearch /var/lib/elasticsearch-6
+    sudo -u root cp -a /var/log/elasticsearch /var/log/elasticsearch-6
+
+    # Remove Elasticsearch 6.x.
+    sudo -u root apt-get purge -y elasticsearch
+    sudo -u root rm -rf /var/lib/elasticsearch /var/log/elasticsearch /etc/elasticsearch
 fi
-sudo -u root apt-get install -y openjdk-11-jdk gnupg
 
-# Set up Elasticsearch 6.x.
-setup_temp_elasticsearch6
-
-# Back up Elasticsearch 6.x directories.
-sudo -u root cp -a /etc/elasticsearch /etc/elasticsearch-6
-sudo -u root cp -a /var/lib/elasticsearch /var/lib/elasticsearch-6
-sudo -u root cp -a /var/log/elasticsearch /var/log/elasticsearch-6
-
-# Remove Elasticsearch 6.x.
-sudo -u root apt-get purge -y elasticsearch
-sudo -u root rm -rf /var/lib/elasticsearch /var/log/elasticsearch /etc/elasticsearch
-
-# Install Elasticsearch 8.x.
+# Install/upgrade Elasticsearch 8.x.
 install_elasticsearch_deb "${elasticsearch_repo_version}" "${elasticsearch_package_version}" "${local_repository}"
 
 sudo -u root systemctl restart elasticsearch
@@ -61,7 +69,7 @@ wait_for_elasticsearch "http://localhost:9200"
 # Configure repository
 #
 
-configure_archivematica_apt_repos "${local_repository}" "${packages_repo_version}"
+configure_archivematica_apt_repos "${local_repository}" "${packages_repo_version}" "${packages_repo_baseurl}"
 
 if [ "${local_repository}" == "true" ]; then
     sudo -u root apt-get -o Acquire::AllowInsecureRepositories=true update
@@ -114,9 +122,11 @@ apt_upgrade_cmd+=(
 
 restart_archivematica_services
 
-# Reindex Elasticsearch data.
-reindex_elasticsearch_data
+if [ "${elasticsearch_migrate_from_6x}" == "true" ]; then
+    # Reindex Elasticsearch data (only needed when migrating from 6.x).
+    reindex_elasticsearch_data
 
-# Delete temporary Elasticsearch 6.x instance.
-cleanup_temp_elasticsearch6
-trap - EXIT
+    # Delete temporary Elasticsearch 6.x instance.
+    cleanup_temp_elasticsearch6
+    trap - EXIT
+fi


### PR DESCRIPTION
This cleans up after running `mk-build-deps` in the `jammy`/`noble` AM and
SS builds, so stray build-deps `.deb/.changes/.buildinfo` files don't
end up inside the produced packages.

It also adds workflow inputs so tests can target alternate Archivematica
repos (e.g., Jenkins artifacts) without rebuilding locally and makes
the Elasticsearch migration optional so it is skipped when the
baseline is already on ES 8.x.

Connected to https://github.com/archivematica/Issues/issues/1766