### PR TITLE
Build Storage Service from uv lock

### DIFF
--- a/debs/jammy/archivematica-storage-service/Dockerfile
+++ b/debs/jammy/archivematica-storage-service/Dockerfile
@@ -1,4 +1,11 @@
+ARG UV_VERSION=0.11.30
+ARG UV_DIGEST=sha256:93b61e21202b1dab861092748e46bbd6e0e41dd84f59b9174efd2353186e1b47
+
+FROM ghcr.io/astral-sh/uv:${UV_VERSION}@${UV_DIGEST} AS uv
+
 FROM ubuntu:jammy
+
+COPY --from=uv /uv /usr/local/bin/uv
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/debs/jammy/archivematica-storage-service/debian-storage-service/rules
+++ b/debs/jammy/archivematica-storage-service/debian-storage-service/rules
@@ -8,6 +8,7 @@ SRC_STAGE := $(CURDIR)/debian/archivematica-storage-service/opt/archivematica/ar
 ABS_RUNTIME := /opt/archivematica/archivematica-storage-service
 FRONTEND_DIR := $(CURDIR)/src/archivematica/storage_service/frontend
 FRONTEND_BUILD_DIR := $(FRONTEND_DIR)/dist
+LOCK_EXPORT := $(CURDIR)/debian/uv-runtime-requirements.txt
 
 %:
 	dh $@ --with python-virtualenv --with systemd
@@ -37,7 +38,11 @@ override_dh_install:
 	rm -rf $(FRONTEND_DIR)/node_modules
 
 override_dh_virtualenv:
-	dh_virtualenv --python=python3 --preinstall "setuptools>=75" --requirements=requirements.txt --skip-install
+	UV_PYTHON=python3 UV_PYTHON_DOWNLOADS=never \
+		uv export --locked --no-dev --no-hashes --no-emit-project \
+			--output-file $(LOCK_EXPORT)
+	dh_virtualenv --python=python3 --preinstall "setuptools>=75" \
+		--requirements=$(LOCK_EXPORT) --skip-install
 	# Bail out if a real installation already exists in the runtime location.
 	if [ -e $(ABS_RUNTIME) ]; then \
 	  echo "$(ABS_RUNTIME) exists; refusing to overwrite" >&2; exit 1; \

--- a/debs/noble/archivematica-storage-service/Dockerfile
+++ b/debs/noble/archivematica-storage-service/Dockerfile
@@ -1,4 +1,11 @@
+ARG UV_VERSION=0.11.30
+ARG UV_DIGEST=sha256:93b61e21202b1dab861092748e46bbd6e0e41dd84f59b9174efd2353186e1b47
+
+FROM ghcr.io/astral-sh/uv:${UV_VERSION}@${UV_DIGEST} AS uv
+
 FROM ubuntu:noble
+
+COPY --from=uv /uv /usr/local/bin/uv
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/debs/noble/archivematica-storage-service/debian-storage-service/rules
+++ b/debs/noble/archivematica-storage-service/debian-storage-service/rules
@@ -8,6 +8,7 @@ SRC_STAGE := $(CURDIR)/debian/archivematica-storage-service/opt/archivematica/ar
 ABS_RUNTIME := /opt/archivematica/archivematica-storage-service
 FRONTEND_DIR := $(CURDIR)/src/archivematica/storage_service/frontend
 FRONTEND_BUILD_DIR := $(FRONTEND_DIR)/dist
+LOCK_EXPORT := $(CURDIR)/debian/uv-runtime-requirements.txt
 
 %:
 	dh $@ --with python-virtualenv --with systemd
@@ -37,7 +38,11 @@ override_dh_install:
 	rm -rf $(FRONTEND_DIR)/node_modules
 
 override_dh_virtualenv:
-	dh_virtualenv --python=python3 --preinstall "setuptools>=75" --requirements=requirements.txt --skip-install
+	UV_PYTHON=python3 UV_PYTHON_DOWNLOADS=never \
+		uv export --locked --no-dev --no-hashes --no-emit-project \
+			--output-file $(LOCK_EXPORT)
+	dh_virtualenv --python=python3 --preinstall "setuptools>=75" \
+		--requirements=$(LOCK_EXPORT) --skip-install
 	# Bail out if a real installation already exists in the runtime location.
 	if [ -e $(ABS_RUNTIME) ]; then \
 	  echo "$(ABS_RUNTIME) exists; refusing to overwrite" >&2; exit 1; \

--- a/rpms/EL9/archivematica-storage-service/Dockerfile
+++ b/rpms/EL9/archivematica-storage-service/Dockerfile
@@ -1,4 +1,11 @@
+ARG UV_VERSION=0.11.30
+ARG UV_DIGEST=sha256:93b61e21202b1dab861092748e46bbd6e0e41dd84f59b9174efd2353186e1b47
+
+FROM ghcr.io/astral-sh/uv:${UV_VERSION}@${UV_DIGEST} AS uv
+
 FROM rockylinux:9
+
+COPY --from=uv /uv /usr/local/bin/uv
 
 RUN set -ex \
     && yum -y update \

--- a/rpms/EL9/archivematica-storage-service/Makefile
+++ b/rpms/EL9/archivematica-storage-service/Makefile
@@ -72,4 +72,4 @@ cleanup:
 		bash -c "rm -rf /src/*.rpm"
 
 rpm-test:
-	@docker run --rm --volume="$(shell pwd):$(DOCKER_VOLUME)" rockylinux:9 bash -c "yum install -y epel-release && yum localinstall -y --nogpgcheck $(DOCKER_VOLUME)/$(NAME)-$(VERSION)*.rpm"
+	@docker run --rm --volume="$(shell pwd):$(DOCKER_VOLUME)" rockylinux:9 bash -c "yum install -y epel-release && yum localinstall -y --nogpgcheck $(DOCKER_VOLUME)/$(NAME)-$(VERSION)*.x86_64.rpm"

--- a/rpms/EL9/archivematica-storage-service/package.spec
+++ b/rpms/EL9/archivematica-storage-service/package.spec
@@ -10,7 +10,7 @@ Group: Application/System
 License: AGPLv3
 Source0: %{git_repo}
 BuildRequires: git, gcc, libffi-devel, openssl-devel, libxslt-devel, python3-virtualenv, python3.12-devel, mariadb-devel, postgresql-devel, gcc-c++, openldap-devel, nodejs >= 24, pkgconfig
-Requires: gnupg, libxslt-devel, policycoreutils-python-utils, python3.12-devel, rng-tools, rsync, nginx, unar, p7zip, shadow-utils, gettext
+Requires: gnupg, libxslt-devel, mariadb-connector-c, policycoreutils-python-utils, python3.12-devel, rng-tools, rsync, nginx, unar, p7zip, shadow-utils, gettext
 AutoReq: No
 AutoProv: No
 %description
@@ -66,7 +66,10 @@ cp -rf %{_sourcedir}/%{name}/. %{buildroot}/opt/archivematica/archivematica-stor
 
 virtualenv --python=python3.12 /usr/share/archivematica/virtualenvs/archivematica-storage-service
 /usr/share/archivematica/virtualenvs/archivematica-storage-service/bin/pip install --upgrade pip setuptools
-/usr/share/archivematica/virtualenvs/archivematica-storage-service/bin/pip install -r %{_sourcedir}/%{name}/requirements.txt
+UV_PYTHON=python3.12 UV_PYTHON_DOWNLOADS=never \
+  uv export --project %{_sourcedir}/%{name} --locked --no-dev --no-hashes \
+    --no-emit-project --output-file %{_builddir}/uv-runtime-requirements.txt
+/usr/share/archivematica/virtualenvs/archivematica-storage-service/bin/pip install -r %{_builddir}/uv-runtime-requirements.txt
 
 # Install the application in editable mode so the source directory under /opt is
 # importable by the virtualenv at runtime.


### PR DESCRIPTION
Install pinned uv in the Debian and RPM build images. Export runtime-only requirements from uv.lock for the existing virtualenv packaging steps.