### PR TITLE
Adopt uv for Archivematica packages

### DIFF
--- a/debs/jammy/archivematica/Dockerfile
+++ b/debs/jammy/archivematica/Dockerfile
@@ -1,4 +1,11 @@
+ARG UV_VERSION=0.11.30
+ARG UV_DIGEST=sha256:93b61e21202b1dab861092748e46bbd6e0e41dd84f59b9174efd2353186e1b47
+
+FROM ghcr.io/astral-sh/uv:${UV_VERSION}@${UV_DIGEST} AS uv
+
 FROM ubuntu:jammy
+
+COPY --from=uv /uv /usr/local/bin/uv
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/debs/jammy/archivematica/debian-archivematica/rules
+++ b/debs/jammy/archivematica/debian-archivematica/rules
@@ -8,6 +8,7 @@ SRC_STAGE := $(CURDIR)/debian/archivematica/opt/archivematica/archivematica
 ABS_RUNTIME := /opt/archivematica/archivematica
 FRONTEND_DIR := $(CURDIR)/src/archivematica/dashboard/frontend
 FRONTEND_BUILD_DIR := $(FRONTEND_DIR)/dist
+LOCK_EXPORT := $(CURDIR)/debian/uv-runtime-requirements.txt
 
 %:
 	dh $@ --with python-virtualenv
@@ -37,7 +38,11 @@ override_dh_install:
 	rm -rf $(FRONTEND_DIR)/node_modules
 
 override_dh_virtualenv:
-	dh_virtualenv --python=python3 --preinstall "setuptools>=75" --requirements=requirements.txt --skip-install
+	UV_PYTHON=python3 UV_PYTHON_DOWNLOADS=never \
+		uv export --locked --no-dev --no-hashes --no-emit-project \
+			--output-file $(LOCK_EXPORT)
+	dh_virtualenv --python=python3 --preinstall "setuptools>=75" \
+		--requirements=$(LOCK_EXPORT) --skip-install
 	# Bail out if a real installation already exists in the runtime location.
 	if [ -e $(ABS_RUNTIME) ]; then \
 	  echo "$(ABS_RUNTIME) exists; refusing to overwrite" >&2; exit 1; \

--- a/debs/noble/archivematica/Dockerfile
+++ b/debs/noble/archivematica/Dockerfile
@@ -1,4 +1,11 @@
+ARG UV_VERSION=0.11.30
+ARG UV_DIGEST=sha256:93b61e21202b1dab861092748e46bbd6e0e41dd84f59b9174efd2353186e1b47
+
+FROM ghcr.io/astral-sh/uv:${UV_VERSION}@${UV_DIGEST} AS uv
+
 FROM ubuntu:noble
+
+COPY --from=uv /uv /usr/local/bin/uv
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/debs/noble/archivematica/debian-archivematica/rules
+++ b/debs/noble/archivematica/debian-archivematica/rules
@@ -8,6 +8,7 @@ SRC_STAGE := $(CURDIR)/debian/archivematica/opt/archivematica/archivematica
 ABS_RUNTIME := /opt/archivematica/archivematica
 FRONTEND_DIR := $(CURDIR)/src/archivematica/dashboard/frontend
 FRONTEND_BUILD_DIR := $(FRONTEND_DIR)/dist
+LOCK_EXPORT := $(CURDIR)/debian/uv-runtime-requirements.txt
 
 %:
 	dh $@ --with python-virtualenv
@@ -37,7 +38,11 @@ override_dh_install:
 	rm -rf $(FRONTEND_DIR)/node_modules
 
 override_dh_virtualenv:
-	dh_virtualenv --python=python3 --preinstall "setuptools>=75" --requirements=requirements.txt --skip-install
+	UV_PYTHON=python3 UV_PYTHON_DOWNLOADS=never \
+		uv export --locked --no-dev --no-hashes --no-emit-project \
+			--output-file $(LOCK_EXPORT)
+	dh_virtualenv --python=python3 --preinstall "setuptools>=75" \
+		--requirements=$(LOCK_EXPORT) --skip-install
 	# Bail out if a real installation already exists in the runtime location.
 	if [ -e $(ABS_RUNTIME) ]; then \
 	  echo "$(ABS_RUNTIME) exists; refusing to overwrite" >&2; exit 1; \

--- a/rpms/EL9/archivematica/Dockerfile
+++ b/rpms/EL9/archivematica/Dockerfile
@@ -1,4 +1,11 @@
+ARG UV_VERSION=0.11.30
+ARG UV_DIGEST=sha256:93b61e21202b1dab861092748e46bbd6e0e41dd84f59b9174efd2353186e1b47
+
+FROM ghcr.io/astral-sh/uv:${UV_VERSION}@${UV_DIGEST} AS uv
+
 FROM rockylinux:9
+
+COPY --from=uv /uv /usr/local/bin/uv
 
 RUN set -ex \
     && yum -y update \

--- a/rpms/EL9/archivematica/archivematica.spec
+++ b/rpms/EL9/archivematica/archivematica.spec
@@ -166,7 +166,10 @@ cp -a %{_sourcedir}/%{name}/. %{buildroot}/opt/archivematica/archivematica/
 # Archivematica virtual environment
 virtualenv --python=python3.12 /usr/share/archivematica/virtualenvs/archivematica
 /usr/share/archivematica/virtualenvs/archivematica/bin/pip install --upgrade pip setuptools
-/usr/share/archivematica/virtualenvs/archivematica/bin/pip install -r %{_sourcedir}/%{name}/requirements.txt
+UV_PYTHON=python3.12 UV_PYTHON_DOWNLOADS=never \
+  uv export --project %{_sourcedir}/%{name} --locked --no-dev --no-hashes \
+    --no-emit-project --output-file %{_builddir}/uv-runtime-requirements.txt
+/usr/share/archivematica/virtualenvs/archivematica/bin/pip install -r %{_builddir}/uv-runtime-requirements.txt
 
 # Install the application in editable mode so the source directory under /opt is
 # importable by the virtualenv at runtime.


### PR DESCRIPTION
Export runtime dependencies from Archivematica's uv.lock for Debian and RPM builds. Add the pinned uv binary to each packaging image.